### PR TITLE
Fixed issues when removing duplicate scene members and duplicate All-Links

### DIFF
--- a/Insteon/Model/Scenes.cs
+++ b/Insteon/Model/Scenes.cs
@@ -257,8 +257,8 @@ namespace Insteon.Model
 
                 foreach(var member in membersToRemove)
                 {
-                    // No need to remove the links as we are removing the device entirely 
-                    // and the links will be removed anyway
+                    // No need to remove the links as we are removing the device entirely
+                    // and that will remove all the links to that device.
                     scene.RemoveMember(member, removeLinks: false);
                 }
             }

--- a/UnitTestApp/Insteon/ModelTestsBase.cs
+++ b/UnitTestApp/Insteon/ModelTestsBase.cs
@@ -117,4 +117,22 @@ public static class HouseExtensions
         await device.TryReadAllLinkDatabaseAsync();
         await house.Hub.TryReadAllLinkDatabaseAsync();
     }
+
+    // Pretend to sync everything by changing statuses to "Synced"
+    internal static void PretendSync(this House house)
+    {
+        foreach (var device in house.Devices)
+        {
+            device.PropertiesSyncStatus = SyncStatus.Synced;
+            device.AllLinkDatabase.LastStatus = SyncStatus.Synced;
+            for (int seq = 0; seq < device.AllLinkDatabase.Count; seq++)
+            {
+                device.AllLinkDatabase[seq] = new(device.AllLinkDatabase[seq]) { SyncStatus = SyncStatus.Synced };
+            }
+            foreach(var channel in device.Channels)
+            {
+                channel.PropertiesSyncStatus = SyncStatus.Synced;
+            }
+        }
+    }
 }

--- a/UnitTestApp/Insteon/TestScenes.cs
+++ b/UnitTestApp/Insteon/TestScenes.cs
@@ -61,11 +61,11 @@ public sealed class TestScenes
     public void TestSceneLoaded()
     {
         Assert.IsNotNull(house);
-        Assert.IsNotNull(house.Scenes, "Has scenes");
-        Assert.IsNotNull(house.Devices, "Has devices");
+        Assert.IsNotNull(house.Scenes, "House has no scenes");
+        Assert.IsNotNull(house.Devices, "House has no devices");
         Assert.IsTrue(house.Devices.Count == 9, "Wrong count of devices");
-        Assert.IsNotNull(house.Scenes.GetSceneById(1), "Has a scene with id == 1");
-        Assert.IsTrue(house.Scenes.GetSceneById(1)!.Members.Count == 7, "Has 7 scenes members");
+        Assert.IsNotNull(house.Scenes.GetSceneById(1), "House doesn't have a scene with id == 1");
+        Assert.IsTrue(house.Scenes.GetSceneById(1)!.Members.Count == 7, "Scene 1 has wrong count of scenes members");
     }
 
     [TestMethod]

--- a/UnitTestApp/Insteon/TestScenesWithDuplicateMembers.cs
+++ b/UnitTestApp/Insteon/TestScenesWithDuplicateMembers.cs
@@ -1,0 +1,187 @@
+/* Copyright 2022 Christian Fortini
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using Common;
+using Insteon.Model;
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests.Insteon;
+
+[TestClass]
+public sealed class TestScenesWithDuplicateMembers
+{
+    House house = null!;
+
+    public TestScenesWithDuplicateMembers()
+    {
+    }
+
+    public TestContext TestContext { get; set; } = null!;
+
+    private void LogFilePath(string path)
+    {
+        // This does not seem to actually be working
+        Microsoft.VisualStudio.TestTools.UnitTesting.Logging.Logger.LogMessage(path);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        // Place breakpoint here to collect the test files
+    }
+
+    [TestInitialize]
+    public async Task Init()
+    {
+        ApplicationType.IsUnitTestFramework = true;
+        var h = await ModelHolderForTest.LoadFromFile("Scenes", "Scene2Expanded");
+        Assert.IsNotNull(h);
+        this.house = h!;
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        house = null!;
+    }
+
+    [TestMethod]
+    public void TestSceneLoaded()
+    {
+        Assert.IsNotNull(house);
+        Assert.IsNotNull(house.Scenes, "House has no scenes");
+        Assert.IsNotNull(house.Devices, "House has no devices");
+        Assert.IsTrue(house.Devices.Count == 9, "Wrong count of devices");
+        Assert.IsNotNull(house.Scenes.GetSceneById(1), "House doesn't have a scene with id == 1");
+        Assert.IsTrue(house.Scenes.GetSceneById(1)!.Members.Count == 9, "Scene 1 has wrong count of scenes members");
+    }
+
+    [TestMethod]
+    public void TestSceneMembers()
+    {
+        Scene scene = house.Scenes.GetSceneById(1)!;
+        Assert.IsTrue(scene.Members[0].DeviceId == "11.11.11");
+        Assert.IsTrue(scene.Members[1].DeviceId == "22.22.22");
+        Assert.IsTrue(scene.Members[2].DeviceId == "33.33.33");
+        Assert.IsTrue(scene.Members[3].DeviceId == "44.44.44");
+        Assert.IsTrue(scene.Members[4].DeviceId == "55.55.55");
+        Assert.IsTrue(scene.Members[5].DeviceId == "55.55.55");
+        Assert.IsTrue(scene.Members[6].DeviceId == "44.44.44");
+        Assert.IsTrue(scene.Members[7].DeviceId == "44.44.44");
+        Assert.IsTrue(scene.Members[8].DeviceId == "11.11.11");
+    }
+
+    [TestMethod]
+    public void TestSceneMemberQueries()
+    {
+        Scene scene = house.Scenes.GetSceneById(1)!;
+
+        // Get a few members by id/group
+        SceneMember? member;
+        Assert.IsTrue(scene.Members.TryGetMember(InsteonID.FromString("11.11.11"), group: 2, isController: true, isResponder: true, out member));
+        Assert.IsTrue(member != null);
+        Assert.IsTrue(member.DeviceId == "11.11.11");
+        Assert.IsTrue(member.Group == 2);
+
+        Assert.IsTrue(scene.Members.TryGetMember(InsteonID.FromString("22.22.22"), group: 1, isController: true, isResponder: true, out member));
+        Assert.IsTrue(member != null);
+        Assert.IsTrue(member.DeviceId == "22.22.22");
+        Assert.IsTrue(member.Group == 1);
+
+        Assert.IsTrue(scene.Members.TryGetMember(InsteonID.FromString("33.33.33"), group: 1, isController: false, isResponder: true, out member));
+        Assert.IsTrue(member != null);
+        Assert.IsTrue(member.DeviceId == "33.33.33");
+        Assert.IsTrue(member.Group == 1);
+
+        Assert.IsTrue(scene.Members.TryGetMember(InsteonID.FromString("44.44.44"), group: 4, isController: false, isResponder: true, out member));
+        Assert.IsTrue(member != null);
+        Assert.IsTrue(member.DeviceId == "44.44.44");
+        Assert.IsTrue(member.Group == 4);
+
+        Assert.IsTrue(scene.Members.TryGetMatchingMembers(InsteonID.FromString("55.55.55"), group: 6, out var matchingMembers));
+        Assert.IsTrue(matchingMembers.Count == 2);
+
+        Assert.IsTrue(scene.Members.TryGetMatchingMembers(InsteonID.FromString("44.44.44"), group: 5, out var matchingMembers2));
+        Assert.IsTrue(matchingMembers2.Count == 2);
+
+        Assert.IsTrue(scene.Members.TryGetMember(InsteonID.FromString("11.11.11"), group: 3, isController: true, isResponder: false, out member));
+        Assert.IsTrue(member != null);
+        Assert.IsTrue(member.DeviceId == "11.11.11");
+        Assert.IsTrue(member.Group == 3);
+
+        // Query all Controllers on a single device
+        Assert.IsTrue(scene.Members.TryGetMatchingControllers(InsteonID.FromString("11.11.11"), out List<SceneMember>? matchingControllers));
+        Assert.IsTrue(matchingControllers!.Count == 2);
+
+        // Query all responders on a single device
+        Assert.IsTrue(scene.Members.TryGetMatchingResponders(InsteonID.FromString("44.44.44"), out List<SceneMember>? matchingResponders));
+        Assert.IsTrue(matchingResponders!.Count == 3);
+    }
+
+    /// <summary>
+    /// This expands a scene with duplicated scene members, creating duplicate links for duplicate members as well as 
+    /// for controllers with multiple responders on same device, so that we can test the removal of duplicates.
+    /// IMPORTANT: This test works off Scenes/Scene2.xml, and creates the content of Refs/Scenes/Scene2Expanded.xml.
+    /// Subsequent Tests work off Scene2Expanded.xml. 
+    /// This allows for more stable record uids making it easier to compare files.
+    /// </summary>
+    [TestMethod]
+    public async Task TestExpandScene()
+    {
+        var house = await ModelHolderForTest.LoadFromFile("Scenes", "Scene2");
+        Assert.IsNotNull(house);
+        Scene scene = house.Scenes.GetSceneById(1)!;
+        scene.Expand(allowDuplicateLinks: true);
+        house.PretendSync();
+        LogFilePath(await ModelHolderForTest.SaveToFile("Scenes2", TestContext.TestName!, this.house));
+        var result = await ModelHolderForTest.CompareFiles("Scenes2", TestContext.TestName!);
+        Assert.IsNull(result, result);
+    }
+
+    /// <summary>
+    /// This tests removing duplicate memmbers one at a time and making sure we end up with the correct links.
+    /// </summary>
+    [TestMethod]
+    public async Task TestRemoveDuplicateMembersOneByOne()
+    {
+        Scene scene = house.Scenes.GetSceneById(1)!;
+        if (scene.Members.TryGetMember(new InsteonID("44.44.44"), group: 5, isController: false, isResponder: true, out var member1))
+        {
+            scene.RemoveMember(member1, removeLinks: true);
+            if (scene.Members.TryGetMember(new InsteonID("55.55.55"), group: 6, isController: true, isResponder: false, out var member2))
+            {
+                scene.RemoveMember(member2, removeLinks: true);
+            }
+        }
+        LogFilePath(await ModelHolderForTest.SaveToFile("Scenes2", TestContext.TestName!, house));
+        var result = await ModelHolderForTest.CompareFiles("Scenes2", TestContext.TestName!);
+        Assert.IsNull(result, result);
+    }
+
+    /// <summary>
+    /// This tests removing duplicate memmbers all at once, simulating using the "Remove Duplicate Members" menu option
+    /// and making sure we end up with the correct links.
+    /// </summary>
+    [TestMethod]
+    public async Task TestRemoveDuplicateMembers()
+    {
+        Scene scene = house.Scenes.GetSceneById(1)!;
+        scene.RemoveDuplicateMembers();
+        LogFilePath(await ModelHolderForTest.SaveToFile("Scenes2", TestContext.TestName!, house));
+        var result = await ModelHolderForTest.CompareFiles("Scenes2", TestContext.TestName!);
+        Assert.IsNull(result, result);
+    }
+}

--- a/UnitTestApp/Models/Scenes/Scene2.xml
+++ b/UnitTestApp/Models/Scenes/Scene2.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="2.0">
+  <application />
+  <insteon>
+    <active_gateways>
+      <gateway insteonID="AA.00.00">
+        <ip port="25105" address="10.0.0.34" />
+      </gateway>
+      <gateway insteonID="BB.00.00">
+        <ip port="25105" address="10.0.0.99" />
+      </gateway>
+    </active_gateways>
+    <active_devices>
+      <device insteonID="AA.00.00" category="3" subcategory="51" revision="165" status="connected" powerline="0" radio="0" hopIfModSyncFails="0" ipk="00.00.00" wattage="0" webDeviceID="0" webGatewayControllerGroup="0" displayName="Hub" active="1">
+      </device>
+      <device insteonID="11.11.11" category="1" subcategory="65" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="-1" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc04DCS" displayName="Keypad - Sink" active="1">
+        <!-- Category 65 is an 8 button keypadlink, which should be reflected in the OperatingFlags bit 3 -->
+        <properties>
+          <p name="operatingFlags">
+            <device value="0x80" />
+          </p>
+        </properties>
+      </device>
+      <device insteonID="22.22.22" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="100" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Cove Lighting" active="1">
+        <!-- See note above -->
+        <properties>
+          <p name="operatingFlags">
+            <device value="0x80" />
+          </p>
+        </properties>
+      </device>
+      <device insteonID="33.33.33" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="20" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Island Cans" active="1">
+      </device>
+      <device insteonID="44.44.44" category="1" subcategory="65" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="20" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc04DCS" displayName="Keypad - Stove Lights" active="1">
+      </device>
+      <device insteonID="55.55.55" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Ceiling Lights" active="1">
+      </device>
+      <device insteonID="AA.AA.AA" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Under Cabinet Lights" active="1">
+      </device>
+      <device insteonID="BB.BB.BB" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Nook Ceiling Lights" active="1">
+      </device>
+      <device insteonID="CC.CC.CC" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Pantry Lights" active="1">
+      </device>
+
+    </active_devices>
+    <scenes nextSceneID="2">
+      <scene id="1" name="Kitchen" lastTrigger="05/17/2014 11:02:08 AM, On" notes="Turn on kitchen main lights">
+        <members>
+          <member iid="11.11.11" group="2" controller="1" responder="1" data1="255" data2="28" data3="2" status="Done" tag="35" />
+          <member iid="22.22.22" group="1" controller="1" responder="1" data1="76" data2="28" data3="1" status="Done" tag="1" />
+          <member iid="33.33.33" group="1" responder="1" data1="153" data2="28" data3="1" status="Done" tag="1" />
+          <member iid="44.44.44" group="4" responder="1" data1="255" data2="28" data3="4" status="Done" tag="35" />
+          <member iid="55.55.55" group="6" controller="1" data1="255" data2="28" data3="6" status="Done" tag="35" />
+          <member iid="55.55.55" group="6" controller="1" data1="255" data2="28" data3="6" status="Done" tag="35" />
+          <member iid="44.44.44" group="5" responder="1" data1="76" data2="28" data3="5" status="Done" tag="33" />
+          <member iid="44.44.44" group="5" responder="1" data1="76" data2="28" data3="5" status="Done" tag="33" />
+          <member iid="11.11.11" group="3" controller="1" data1="160" data2="28" data3="3" status="Done" tag="35" />
+        </members>
+      </scene>
+    </scenes>
+  </insteon>
+</settings>

--- a/UnitTestApp/Models/Scenes/Scene2Expanded.xml
+++ b/UnitTestApp/Models/Scenes/Scene2Expanded.xml
@@ -1,0 +1,900 @@
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="2.0">
+  <application />
+  <insteon>
+    <active_gateways>
+      <gateway insteonID="AA.00.00">
+        <ip port="25105" address="10.0.0.34" />
+      </gateway>
+      <gateway insteonID="BB.00.00">
+        <ip port="25105" address="10.0.0.99" />
+      </gateway>
+    </active_gateways>
+    <active_devices>
+      <device insteonID="AA.00.00" category="3" subcategory="51" revision="165" status="connected" powerline="0" radio="0" hopIfModSyncFails="0" ipk="00.00.00" wattage="0" webDeviceID="0" webGatewayControllerGroup="0" displayName="Hub" active="1">
+        <location />
+        <channels>
+          <channel id="0" lastStatus="Synchronized" />
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+          <channel id="7" lastStatus="Synchronized" />
+          <channel id="8" lastStatus="Synchronized" />
+          <channel id="9" lastStatus="Synchronized" />
+          <channel id="10" lastStatus="Synchronized" />
+          <channel id="11" lastStatus="Synchronized" />
+          <channel id="12" lastStatus="Synchronized" />
+          <channel id="13" lastStatus="Synchronized" />
+          <channel id="14" lastStatus="Synchronized" />
+          <channel id="15" lastStatus="Synchronized" />
+          <channel id="16" lastStatus="Synchronized" />
+          <channel id="17" lastStatus="Synchronized" />
+          <channel id="18" lastStatus="Synchronized" />
+          <channel id="19" lastStatus="Synchronized" />
+          <channel id="20" lastStatus="Synchronized" />
+          <channel id="21" lastStatus="Synchronized" />
+          <channel id="22" lastStatus="Synchronized" />
+          <channel id="23" lastStatus="Synchronized" />
+          <channel id="24" lastStatus="Synchronized" />
+          <channel id="25" lastStatus="Synchronized" />
+          <channel id="26" lastStatus="Synchronized" />
+          <channel id="27" lastStatus="Synchronized" />
+          <channel id="28" lastStatus="Synchronized" />
+          <channel id="29" lastStatus="Synchronized" />
+          <channel id="30" lastStatus="Synchronized" />
+          <channel id="31" lastStatus="Synchronized" />
+          <channel id="32" lastStatus="Synchronized" />
+          <channel id="33" lastStatus="Synchronized" />
+          <channel id="34" lastStatus="Synchronized" />
+          <channel id="35" lastStatus="Synchronized" />
+          <channel id="36" lastStatus="Synchronized" />
+          <channel id="37" lastStatus="Synchronized" />
+          <channel id="38" lastStatus="Synchronized" />
+          <channel id="39" lastStatus="Synchronized" />
+          <channel id="40" lastStatus="Synchronized" />
+          <channel id="41" lastStatus="Synchronized" />
+          <channel id="42" lastStatus="Synchronized" />
+          <channel id="43" lastStatus="Synchronized" />
+          <channel id="44" lastStatus="Synchronized" />
+          <channel id="45" lastStatus="Synchronized" />
+          <channel id="46" lastStatus="Synchronized" />
+          <channel id="47" lastStatus="Synchronized" />
+          <channel id="48" lastStatus="Synchronized" />
+          <channel id="49" lastStatus="Synchronized" />
+          <channel id="50" lastStatus="Synchronized" />
+          <channel id="51" lastStatus="Synchronized" />
+          <channel id="52" lastStatus="Synchronized" />
+          <channel id="53" lastStatus="Synchronized" />
+          <channel id="54" lastStatus="Synchronized" />
+          <channel id="55" lastStatus="Synchronized" />
+          <channel id="56" lastStatus="Synchronized" />
+          <channel id="57" lastStatus="Synchronized" />
+          <channel id="58" lastStatus="Synchronized" />
+          <channel id="59" lastStatus="Synchronized" />
+          <channel id="60" lastStatus="Synchronized" />
+          <channel id="61" lastStatus="Synchronized" />
+          <channel id="62" lastStatus="Synchronized" />
+          <channel id="63" lastStatus="Synchronized" />
+          <channel id="64" lastStatus="Synchronized" />
+          <channel id="65" lastStatus="Synchronized" />
+          <channel id="66" lastStatus="Synchronized" />
+          <channel id="67" lastStatus="Synchronized" />
+          <channel id="68" lastStatus="Synchronized" />
+          <channel id="69" lastStatus="Synchronized" />
+          <channel id="70" lastStatus="Synchronized" />
+          <channel id="71" lastStatus="Synchronized" />
+          <channel id="72" lastStatus="Synchronized" />
+          <channel id="73" lastStatus="Synchronized" />
+          <channel id="74" lastStatus="Synchronized" />
+          <channel id="75" lastStatus="Synchronized" />
+          <channel id="76" lastStatus="Synchronized" />
+          <channel id="77" lastStatus="Synchronized" />
+          <channel id="78" lastStatus="Synchronized" />
+          <channel id="79" lastStatus="Synchronized" />
+          <channel id="80" lastStatus="Synchronized" />
+          <channel id="81" lastStatus="Synchronized" />
+          <channel id="82" lastStatus="Synchronized" />
+          <channel id="83" lastStatus="Synchronized" />
+          <channel id="84" lastStatus="Synchronized" />
+          <channel id="85" lastStatus="Synchronized" />
+          <channel id="86" lastStatus="Synchronized" />
+          <channel id="87" lastStatus="Synchronized" />
+          <channel id="88" lastStatus="Synchronized" />
+          <channel id="89" lastStatus="Synchronized" />
+          <channel id="90" lastStatus="Synchronized" />
+          <channel id="91" lastStatus="Synchronized" />
+          <channel id="92" lastStatus="Synchronized" />
+          <channel id="93" lastStatus="Synchronized" />
+          <channel id="94" lastStatus="Synchronized" />
+          <channel id="95" lastStatus="Synchronized" />
+          <channel id="96" lastStatus="Synchronized" />
+          <channel id="97" lastStatus="Synchronized" />
+          <channel id="98" lastStatus="Synchronized" />
+          <channel id="99" lastStatus="Synchronized" />
+          <channel id="100" lastStatus="Synchronized" />
+          <channel id="101" lastStatus="Synchronized" />
+          <channel id="102" lastStatus="Synchronized" />
+          <channel id="103" lastStatus="Synchronized" />
+          <channel id="104" lastStatus="Synchronized" />
+          <channel id="105" lastStatus="Synchronized" />
+          <channel id="106" lastStatus="Synchronized" />
+          <channel id="107" lastStatus="Synchronized" />
+          <channel id="108" lastStatus="Synchronized" />
+          <channel id="109" lastStatus="Synchronized" />
+          <channel id="110" lastStatus="Synchronized" />
+          <channel id="111" lastStatus="Synchronized" />
+          <channel id="112" lastStatus="Synchronized" />
+          <channel id="113" lastStatus="Synchronized" />
+          <channel id="114" lastStatus="Synchronized" />
+          <channel id="115" lastStatus="Synchronized" />
+          <channel id="116" lastStatus="Synchronized" />
+          <channel id="117" lastStatus="Synchronized" />
+          <channel id="118" lastStatus="Synchronized" />
+          <channel id="119" lastStatus="Synchronized" />
+          <channel id="120" lastStatus="Synchronized" />
+          <channel id="121" lastStatus="Synchronized" />
+          <channel id="122" lastStatus="Synchronized" />
+          <channel id="123" lastStatus="Synchronized" />
+          <channel id="124" lastStatus="Synchronized" />
+          <channel id="125" lastStatus="Synchronized" />
+          <channel id="126" lastStatus="Synchronized" />
+          <channel id="127" lastStatus="Synchronized" />
+          <channel id="128" lastStatus="Synchronized" />
+          <channel id="129" lastStatus="Synchronized" />
+          <channel id="130" lastStatus="Synchronized" />
+          <channel id="131" lastStatus="Synchronized" />
+          <channel id="132" lastStatus="Synchronized" />
+          <channel id="133" lastStatus="Synchronized" />
+          <channel id="134" lastStatus="Synchronized" />
+          <channel id="135" lastStatus="Synchronized" />
+          <channel id="136" lastStatus="Synchronized" />
+          <channel id="137" lastStatus="Synchronized" />
+          <channel id="138" lastStatus="Synchronized" />
+          <channel id="139" lastStatus="Synchronized" />
+          <channel id="140" lastStatus="Synchronized" />
+          <channel id="141" lastStatus="Synchronized" />
+          <channel id="142" lastStatus="Synchronized" />
+          <channel id="143" lastStatus="Synchronized" />
+          <channel id="144" lastStatus="Synchronized" />
+          <channel id="145" lastStatus="Synchronized" />
+          <channel id="146" lastStatus="Synchronized" />
+          <channel id="147" lastStatus="Synchronized" />
+          <channel id="148" lastStatus="Synchronized" />
+          <channel id="149" lastStatus="Synchronized" />
+          <channel id="150" lastStatus="Synchronized" />
+          <channel id="151" lastStatus="Synchronized" />
+          <channel id="152" lastStatus="Synchronized" />
+          <channel id="153" lastStatus="Synchronized" />
+          <channel id="154" lastStatus="Synchronized" />
+          <channel id="155" lastStatus="Synchronized" />
+          <channel id="156" lastStatus="Synchronized" />
+          <channel id="157" lastStatus="Synchronized" />
+          <channel id="158" lastStatus="Synchronized" />
+          <channel id="159" lastStatus="Synchronized" />
+          <channel id="160" lastStatus="Synchronized" />
+          <channel id="161" lastStatus="Synchronized" />
+          <channel id="162" lastStatus="Synchronized" />
+          <channel id="163" lastStatus="Synchronized" />
+          <channel id="164" lastStatus="Synchronized" />
+          <channel id="165" lastStatus="Synchronized" />
+          <channel id="166" lastStatus="Synchronized" />
+          <channel id="167" lastStatus="Synchronized" />
+          <channel id="168" lastStatus="Synchronized" />
+          <channel id="169" lastStatus="Synchronized" />
+          <channel id="170" lastStatus="Synchronized" />
+          <channel id="171" lastStatus="Synchronized" />
+          <channel id="172" lastStatus="Synchronized" />
+          <channel id="173" lastStatus="Synchronized" />
+          <channel id="174" lastStatus="Synchronized" />
+          <channel id="175" lastStatus="Synchronized" />
+          <channel id="176" lastStatus="Synchronized" />
+          <channel id="177" lastStatus="Synchronized" />
+          <channel id="178" lastStatus="Synchronized" />
+          <channel id="179" lastStatus="Synchronized" />
+          <channel id="180" lastStatus="Synchronized" />
+          <channel id="181" lastStatus="Synchronized" />
+          <channel id="182" lastStatus="Synchronized" />
+          <channel id="183" lastStatus="Synchronized" />
+          <channel id="184" lastStatus="Synchronized" />
+          <channel id="185" lastStatus="Synchronized" />
+          <channel id="186" lastStatus="Synchronized" />
+          <channel id="187" lastStatus="Synchronized" />
+          <channel id="188" lastStatus="Synchronized" />
+          <channel id="189" lastStatus="Synchronized" />
+          <channel id="190" lastStatus="Synchronized" />
+          <channel id="191" lastStatus="Synchronized" />
+          <channel id="192" lastStatus="Synchronized" />
+          <channel id="193" lastStatus="Synchronized" />
+          <channel id="194" lastStatus="Synchronized" />
+          <channel id="195" lastStatus="Synchronized" />
+          <channel id="196" lastStatus="Synchronized" />
+          <channel id="197" lastStatus="Synchronized" />
+          <channel id="198" lastStatus="Synchronized" />
+          <channel id="199" lastStatus="Synchronized" />
+          <channel id="200" lastStatus="Synchronized" />
+          <channel id="201" lastStatus="Synchronized" />
+          <channel id="202" lastStatus="Synchronized" />
+          <channel id="203" lastStatus="Synchronized" />
+          <channel id="204" lastStatus="Synchronized" />
+          <channel id="205" lastStatus="Synchronized" />
+          <channel id="206" lastStatus="Synchronized" />
+          <channel id="207" lastStatus="Synchronized" />
+          <channel id="208" lastStatus="Synchronized" />
+          <channel id="209" lastStatus="Synchronized" />
+          <channel id="210" lastStatus="Synchronized" />
+          <channel id="211" lastStatus="Synchronized" />
+          <channel id="212" lastStatus="Synchronized" />
+          <channel id="213" lastStatus="Synchronized" />
+          <channel id="214" lastStatus="Synchronized" />
+          <channel id="215" lastStatus="Synchronized" />
+          <channel id="216" lastStatus="Synchronized" />
+          <channel id="217" lastStatus="Synchronized" />
+          <channel id="218" lastStatus="Synchronized" />
+          <channel id="219" lastStatus="Synchronized" />
+          <channel id="220" lastStatus="Synchronized" />
+          <channel id="221" lastStatus="Synchronized" />
+          <channel id="222" lastStatus="Synchronized" />
+          <channel id="223" lastStatus="Synchronized" />
+          <channel id="224" lastStatus="Synchronized" />
+          <channel id="225" lastStatus="Synchronized" />
+          <channel id="226" lastStatus="Synchronized" />
+          <channel id="227" lastStatus="Synchronized" />
+          <channel id="228" lastStatus="Synchronized" />
+          <channel id="229" lastStatus="Synchronized" />
+          <channel id="230" lastStatus="Synchronized" />
+          <channel id="231" lastStatus="Synchronized" />
+          <channel id="232" lastStatus="Synchronized" />
+          <channel id="233" lastStatus="Synchronized" />
+          <channel id="234" lastStatus="Synchronized" />
+          <channel id="235" lastStatus="Synchronized" />
+          <channel id="236" lastStatus="Synchronized" />
+          <channel id="237" lastStatus="Synchronized" />
+          <channel id="238" lastStatus="Synchronized" />
+          <channel id="239" lastStatus="Synchronized" />
+          <channel id="240" lastStatus="Synchronized" />
+          <channel id="241" lastStatus="Synchronized" />
+          <channel id="242" lastStatus="Synchronized" />
+          <channel id="243" lastStatus="Synchronized" />
+          <channel id="244" lastStatus="Synchronized" />
+          <channel id="245" lastStatus="Synchronized" />
+          <channel id="246" lastStatus="Synchronized" />
+          <channel id="247" lastStatus="Synchronized" />
+          <channel id="248" lastStatus="Synchronized" />
+          <channel id="249" lastStatus="Synchronized" />
+          <channel id="250" lastStatus="Synchronized" />
+          <channel id="251" lastStatus="Synchronized" />
+          <channel id="252" lastStatus="Synchronized" />
+          <channel id="253" lastStatus="Synchronized" />
+          <channel id="254" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:13:42 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="11.11.11" category="1" subcategory="65" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="-1" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc04DCS" displayName="Keypad - Sink" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized">
+            <onMask>
+              <device value="2" lastUpdate="12/19/2024 10:13:35 AM" />
+            </onMask>
+            <onLevel>
+              <device value="255" lastUpdate="12/19/2024 10:13:35 AM" />
+            </onLevel>
+            <rampRate>
+              <device value="28" lastUpdate="12/19/2024 10:13:35 AM" />
+            </rampRate>
+          </channel>
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 11:04:40 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="153239835" />
+          </record>
+          <record sequence="1">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3422902834" />
+          </record>
+          <record sequence="2">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="288318048" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="1532113370" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="2027693251" />
+          </record>
+          <record sequence="5">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3803169358" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="1046786131" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="356120718" />
+          </record>
+          <record sequence="8">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="2364546963" />
+          </record>
+          <record sequence="9">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="943266660" />
+          </record>
+          <record sequence="10">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3846168585" />
+          </record>
+          <record sequence="11">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="1480671700" />
+          </record>
+          <record sequence="12">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="1368183546" />
+          </record>
+          <record sequence="13">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3035674208" />
+          </record>
+          <record sequence="14">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="2248335419" />
+          </record>
+          <record sequence="15">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3197168810" />
+          </record>
+          <record sequence="16">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="798978329" />
+          </record>
+          <record sequence="17">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="1325247071" />
+          </record>
+          <record sequence="18">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3590981323" />
+          </record>
+          <record sequence="19">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3916920783" />
+          </record>
+          <record sequence="20">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3380914991" />
+          </record>
+          <record sequence="21">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3239312937" />
+          </record>
+          <record sequence="22">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3809891253" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3849306870" />
+          </record>
+          <record sequence="24">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="2191986306" />
+          </record>
+          <record sequence="25">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="379073835" />
+          </record>
+          <record sequence="26">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="4064844384" />
+          </record>
+          <record sequence="27">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="468962577" />
+          </record>
+          <record sequence="28">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="417251645" />
+          </record>
+          <record sequence="29">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3111377326" />
+          </record>
+          <record sequence="30">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="1470015737" />
+          </record>
+          <record sequence="31">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3248977371" />
+          </record>
+          <record sequence="32">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="1802163777" />
+          </record>
+          <record sequence="33">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3929922712" />
+          </record>
+          <record sequence="34">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3962420010" />
+          </record>
+          <record sequence="35">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="1227735179" />
+          </record>
+          <record sequence="36">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="2809314202" />
+          </record>
+          <record sequence="37">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3382130665" />
+          </record>
+          <record sequence="38">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="2708729408" />
+          </record>
+          <record sequence="39">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="2704670422" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized">
+          <p name="operatingFlags">
+            <device value="0x80" lastUpdate="12/19/2024 10:13:35 AM" />
+          </p>
+        </properties>
+      </device>
+      <device insteonID="22.22.22" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="100" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Cove Lighting" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/19/2024 11:04:40 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="164402797" />
+          </record>
+          <record sequence="1">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="1294403059" />
+          </record>
+          <record sequence="2">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="3620933688" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="76276406" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2881720383" />
+          </record>
+          <record sequence="5">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="3352794293" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="2744904854" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1081503" />
+          </record>
+          <record sequence="8">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="2225941200" />
+          </record>
+          <record sequence="9">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1189343867" />
+          </record>
+          <record sequence="10">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2929919737" />
+          </record>
+          <record sequence="11">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="515450109" />
+          </record>
+          <record sequence="12">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="3483277612" />
+          </record>
+          <record sequence="13">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2523956666" />
+          </record>
+          <record sequence="14">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="751552240" />
+          </record>
+          <record sequence="15">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="39960775" />
+          </record>
+          <record sequence="16">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1593359211" />
+          </record>
+          <record sequence="17">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="3817997440" />
+          </record>
+          <record sequence="18">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="3632613276" />
+          </record>
+          <record sequence="19">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="1346764324" />
+          </record>
+          <record sequence="20">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2250912993" />
+          </record>
+          <record sequence="21">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="3747120858" />
+          </record>
+          <record sequence="22">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="1808260376" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2408604460" />
+          </record>
+          <record sequence="24">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1826940464" />
+          </record>
+          <record sequence="25">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="2521921366" />
+          </record>
+          <record sequence="26">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1159424975" />
+          </record>
+          <record sequence="27">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="3436235587" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized">
+          <p name="operatingFlags">
+            <device value="0x80" lastUpdate="12/19/2024 10:13:35 AM" />
+          </p>
+        </properties>
+      </device>
+      <device insteonID="33.33.33" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="20" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Island Cans" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/19/2024 11:04:40 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="826194698" />
+          </record>
+          <record sequence="1">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="769512099" />
+          </record>
+          <record sequence="2">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2631277828" />
+          </record>
+          <record sequence="3">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="1414069123" />
+          </record>
+          <record sequence="4">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="3152810492" />
+          </record>
+          <record sequence="5">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2635434951" />
+          </record>
+          <record sequence="6">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="4004517134" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="897946518" />
+          </record>
+          <record sequence="8">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="3304652418" />
+          </record>
+          <record sequence="9">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2773947999" />
+          </record>
+          <record sequence="10">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2557239114" />
+          </record>
+          <record sequence="11">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2779344193" />
+          </record>
+          <record sequence="12">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="1246774102" />
+          </record>
+          <record sequence="13">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="3473016110" />
+          </record>
+          <record sequence="14">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="263461420" />
+          </record>
+          <record sequence="15">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="152069077" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="44.44.44" category="1" subcategory="65" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="20" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc04DCS" displayName="Keypad - Stove Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 11:04:40 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3350787379" />
+          </record>
+          <record sequence="1">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="4087967961" />
+          </record>
+          <record sequence="2">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="51487738" />
+          </record>
+          <record sequence="3">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3142774219" />
+          </record>
+          <record sequence="4">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="1996605221" />
+          </record>
+          <record sequence="5">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="1959111034" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="282612497" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2781955440" />
+          </record>
+          <record sequence="8">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3262628121" />
+          </record>
+          <record sequence="9">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="2590255222" />
+          </record>
+          <record sequence="10">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2571491210" />
+          </record>
+          <record sequence="11">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3964476100" />
+          </record>
+          <record sequence="12">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="45737954" />
+          </record>
+          <record sequence="13">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="4196016352" />
+          </record>
+          <record sequence="14">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="199642022" />
+          </record>
+          <record sequence="15">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="4211626962" />
+          </record>
+          <record sequence="16">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2514296288" />
+          </record>
+          <record sequence="17">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3697521159" />
+          </record>
+          <record sequence="18">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="2603900541" />
+          </record>
+          <record sequence="19">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="206552202" />
+          </record>
+          <record sequence="20">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="850407712" />
+          </record>
+          <record sequence="21">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="2330772681" />
+          </record>
+          <record sequence="22">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2057644997" />
+          </record>
+          <record sequence="23">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2518671397" />
+          </record>
+          <record sequence="24">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="1468329277" />
+          </record>
+          <record sequence="25">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="993388565" />
+          </record>
+          <record sequence="26">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2840873367" />
+          </record>
+          <record sequence="27">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3076418730" />
+          </record>
+          <record sequence="28">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2186245660" />
+          </record>
+          <record sequence="29">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2453929577" />
+          </record>
+          <record sequence="30">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3977659963" />
+          </record>
+          <record sequence="31">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2731998862" />
+          </record>
+          <record sequence="32">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="1813322657" />
+          </record>
+          <record sequence="33">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3764318011" />
+          </record>
+          <record sequence="34">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3474631450" />
+          </record>
+          <record sequence="35">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3064685202" />
+          </record>
+          <record sequence="36">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="189491713" />
+          </record>
+          <record sequence="37">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3155725610" />
+          </record>
+          <record sequence="38">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="115406504" />
+          </record>
+          <record sequence="39">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="1153684263" />
+          </record>
+          <record sequence="40">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="1099224173" />
+          </record>
+          <record sequence="41">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="410608252" />
+          </record>
+          <record sequence="42">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3897768486" />
+          </record>
+          <record sequence="43">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="1804700244" />
+          </record>
+          <record sequence="44">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2260289485" />
+          </record>
+          <record sequence="45">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="1158730727" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="55.55.55" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Ceiling Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 11:04:40 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1706056445" />
+          </record>
+          <record sequence="1">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2818746250" />
+          </record>
+          <record sequence="2">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1641301605" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2300720991" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="213552785" />
+          </record>
+          <record sequence="5">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2217758658" />
+          </record>
+          <record sequence="6">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="122513804" />
+          </record>
+          <record sequence="7">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1944693029" />
+          </record>
+          <record sequence="8">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="429858621" />
+          </record>
+          <record sequence="9">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3122335706" />
+          </record>
+          <record sequence="10">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2153423724" />
+          </record>
+          <record sequence="11">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3825008370" />
+          </record>
+          <record sequence="12">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1995529170" />
+          </record>
+          <record sequence="13">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="635833886" />
+          </record>
+          <record sequence="14">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2822527601" />
+          </record>
+          <record sequence="15">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2041695386" />
+          </record>
+          <record sequence="16">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1459352785" />
+          </record>
+          <record sequence="17">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3095619418" />
+          </record>
+          <record sequence="18">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="323132048" />
+          </record>
+          <record sequence="19">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3265053426" />
+          </record>
+          <record sequence="20">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3458335817" />
+          </record>
+          <record sequence="21">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1983534218" />
+          </record>
+          <record sequence="22">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3348750453" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1236220472" />
+          </record>
+          <record sequence="24">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="432819161" />
+          </record>
+          <record sequence="25">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1705634178" />
+          </record>
+          <record sequence="26">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2323067757" />
+          </record>
+          <record sequence="27">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2140353593" />
+          </record>
+          <record sequence="28">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="740627246" />
+          </record>
+          <record sequence="29">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="4066165554" />
+          </record>
+          <record sequence="30">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3362706785" />
+          </record>
+          <record sequence="31">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3221708381" />
+          </record>
+          <record sequence="32">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3503986454" />
+          </record>
+          <record sequence="33">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1303264596" />
+          </record>
+          <record sequence="34">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1542211798" />
+          </record>
+          <record sequence="35">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2840975989" />
+          </record>
+          <record sequence="36">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="604795073" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="AA.AA.AA" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Under Cabinet Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="BB.BB.BB" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Nook Ceiling Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="CC.CC.CC" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Pantry Lights" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+    </active_devices>
+    <scenes nextSceneID="2">
+      <scene id="1" name="Kitchen" lastTrigger="05/17/2014 11:02:08 AM, On" notes="Turn on kitchen main lights">
+        <members>
+          <member iid="11.11.11" group="2" controller="1" responder="1" data1="255" data2="28" data3="2" status="Done" tag="35" />
+          <member iid="22.22.22" group="1" controller="1" responder="1" data1="76" data2="28" data3="1" status="Done" tag="1" />
+          <member iid="33.33.33" group="1" responder="1" data1="153" data2="28" data3="1" status="Done" tag="1" />
+          <member iid="44.44.44" group="4" responder="1" data1="255" data2="28" data3="4" status="Done" tag="35" />
+          <member iid="55.55.55" group="6" controller="1" data1="255" data2="28" data3="6" status="Done" tag="35" />
+          <member iid="55.55.55" group="6" controller="1" data1="255" data2="28" data3="6" status="Done" tag="35" />
+          <member iid="44.44.44" group="5" responder="1" data1="76" data2="28" data3="5" status="Done" tag="33" />
+          <member iid="44.44.44" group="5" responder="1" data1="76" data2="28" data3="5" status="Done" tag="33" />
+          <member iid="11.11.11" group="3" controller="1" data1="160" data2="28" data3="3" status="Done" tag="35" />
+        </members>
+      </scene>
+    </scenes>
+  </insteon>
+</settings>

--- a/UnitTestApp/Refs/Changes/TestRemoveDuplicateSceneMember.xml
+++ b/UnitTestApp/Refs/Changes/TestRemoveDuplicateSceneMember.xml
@@ -558,7 +558,7 @@
             <device address="AA.00.00" group="4" recordControl="162" data1="255" data2="28" data3="6" scene="12" syncstatus="synced" uid="1759536095" />
           </record>
           <record sequence="13">
-            <device address="BB.66.66" group="4" recordControl="162" data1="255" data2="28" data3="8" scene="20" syncstatus="changed" uid="1364335577" />
+            <device address="BB.66.66" group="4" recordControl="162" data1="255" data2="28" data3="8" scene="20" syncstatus="changed" uid="3486909313" />
           </record>
           <record sequence="14">
             <device address="AA.44.44" group="8" recordControl="162" data1="255" data2="0" data3="7" scene="4" syncstatus="synced" uid="448626210" />
@@ -573,7 +573,7 @@
             <device address="BB.66.66" group="7" recordControl="226" data1="3" data2="0" data3="7" scene="4" syncstatus="synced" uid="1147374401" />
           </record>
           <record sequence="18">
-            <device address="BB.66.66" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="20" syncstatus="synced" uid="3255523099" />
+            <device address="BB.66.66" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="20" syncstatus="changed" uid="1233590364" />
           </record>
           <record sequence="19">
             <device address="AA.44.44" group="7" recordControl="226" data1="3" data2="0" data3="7" scene="4" syncstatus="synced" uid="45176265" />
@@ -648,7 +648,7 @@
             <device address="BB.66.66" group="6" recordControl="162" data1="0" data2="28" data3="3" scene="11" syncstatus="synced" uid="1522509858" />
           </record>
           <record sequence="43">
-            <device address="BB.66.66" group="8" recordControl="98" data1="3" data2="28" data3="8" scene="20" syncstatus="changed" uid="1091643091" />
+            <device address="BB.66.66" group="8" recordControl="98" data1="3" data2="28" data3="8" scene="20" syncstatus="changed" uid="2519592394" />
           </record>
           <record sequence="44">
             <device address="BB.66.66" group="8" recordControl="162" data1="255" data2="28" data3="3" scene="19" syncstatus="synced" uid="2039575949" />
@@ -1216,7 +1216,7 @@
             <device address="AA.44.44" group="6" recordControl="162" data1="255" data2="28" data3="6" scene="11" syncstatus="synced" uid="976428886" />
           </record>
           <record sequence="4">
-            <device address="BB.22.22" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="synced" uid="3974388577" />
+            <device address="BB.22.22" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="2368129022" />
           </record>
           <record sequence="5">
             <device address="AA.11.11" group="1" recordControl="162" data1="255" data2="28" data3="6" scene="11" syncstatus="synced" uid="3515307682" />
@@ -1252,7 +1252,7 @@
             <device address="AA.22.22" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="19" syncstatus="synced" uid="1725603950" />
           </record>
           <record sequence="16">
-            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="1264204182" />
+            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="1241371618" />
           </record>
           <record sequence="17">
             <device address="AA.AA.AA" group="3" recordControl="162" data1="0" data2="28" data3="3" scene="18" syncstatus="synced" uid="1544114227" />
@@ -1309,16 +1309,16 @@
             <device address="AA.11.11" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="4" syncstatus="synced" uid="3453202698" />
           </record>
           <record sequence="35">
-            <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="synced" uid="3909262798" />
+            <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="2331751906" />
           </record>
           <record sequence="36">
-            <device address="AA.11.11" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="2258557984" />
+            <device address="AA.11.11" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="1820153580" />
           </record>
           <record sequence="37">
             <device address="AA.44.44" group="5" recordControl="250" data1="3" data2="28" data3="5" scene="0" syncstatus="synced" uid="1328379597" />
           </record>
           <record sequence="38">
-            <device address="BB.22.22" group="5" recordControl="162" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="4028815863" />
+            <device address="BB.22.22" group="5" recordControl="162" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="3190647499" />
           </record>
           <record sequence="39">
             <device address="AA.00.00" group="6" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1805094016" />
@@ -1327,13 +1327,13 @@
             <device address="AA.11.11" group="7" recordControl="162" data1="255" data2="28" data3="7" scene="4" syncstatus="synced" uid="1530339041" />
           </record>
           <record sequence="41">
-            <device address="AA.11.11" group="8" recordControl="162" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="2818856112" />
+            <device address="AA.11.11" group="8" recordControl="162" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="3249173802" />
           </record>
           <record sequence="42">
-            <device address="BB.22.22" group="5" recordControl="34" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="2062290925" />
+            <device address="BB.22.22" group="5" recordControl="34" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="3078859602" />
           </record>
           <record sequence="43">
-            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="143810047" />
+            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="4053942530" />
           </record>
           <record sequence="44">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="2798743367" />
@@ -2230,13 +2230,13 @@
             <device address="AA.BB.BB" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="3" syncstatus="synced" uid="3480740412" />
           </record>
           <record sequence="19">
-            <device address="BB.66.66" group="4" recordControl="162" data1="255" data2="28" data3="5" scene="20" syncstatus="changed" uid="711620596" />
+            <device address="BB.66.66" group="4" recordControl="162" data1="255" data2="28" data3="5" scene="20" syncstatus="changed" uid="2972841751" />
           </record>
           <record sequence="20">
             <device address="AA.11.11" group="8" recordControl="162" data1="255" data2="28" data3="5" scene="20" syncstatus="synced" uid="3536796012" />
           </record>
           <record sequence="21">
-            <device address="BB.66.66" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="20" syncstatus="synced" uid="338996528" />
+            <device address="BB.66.66" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="20" syncstatus="changed" uid="882384342" />
           </record>
           <record sequence="22">
             <device address="AA.11.11" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="20" syncstatus="synced" uid="2134301513" />

--- a/UnitTestApp/Refs/Scenes2/TestExpandScene.xml
+++ b/UnitTestApp/Refs/Scenes2/TestExpandScene.xml
@@ -1,0 +1,900 @@
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="2.0">
+  <application />
+  <insteon>
+    <active_gateways>
+      <gateway insteonID="AA.00.00">
+        <ip port="25105" address="10.0.0.34" />
+      </gateway>
+      <gateway insteonID="BB.00.00">
+        <ip port="25105" address="10.0.0.99" />
+      </gateway>
+    </active_gateways>
+    <active_devices>
+      <device insteonID="AA.00.00" category="3" subcategory="51" revision="165" status="connected" powerline="0" radio="0" hopIfModSyncFails="0" ipk="00.00.00" wattage="0" webDeviceID="0" webGatewayControllerGroup="0" displayName="Hub" active="1">
+        <location />
+        <channels>
+          <channel id="0" lastStatus="Synchronized" />
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+          <channel id="7" lastStatus="Synchronized" />
+          <channel id="8" lastStatus="Synchronized" />
+          <channel id="9" lastStatus="Synchronized" />
+          <channel id="10" lastStatus="Synchronized" />
+          <channel id="11" lastStatus="Synchronized" />
+          <channel id="12" lastStatus="Synchronized" />
+          <channel id="13" lastStatus="Synchronized" />
+          <channel id="14" lastStatus="Synchronized" />
+          <channel id="15" lastStatus="Synchronized" />
+          <channel id="16" lastStatus="Synchronized" />
+          <channel id="17" lastStatus="Synchronized" />
+          <channel id="18" lastStatus="Synchronized" />
+          <channel id="19" lastStatus="Synchronized" />
+          <channel id="20" lastStatus="Synchronized" />
+          <channel id="21" lastStatus="Synchronized" />
+          <channel id="22" lastStatus="Synchronized" />
+          <channel id="23" lastStatus="Synchronized" />
+          <channel id="24" lastStatus="Synchronized" />
+          <channel id="25" lastStatus="Synchronized" />
+          <channel id="26" lastStatus="Synchronized" />
+          <channel id="27" lastStatus="Synchronized" />
+          <channel id="28" lastStatus="Synchronized" />
+          <channel id="29" lastStatus="Synchronized" />
+          <channel id="30" lastStatus="Synchronized" />
+          <channel id="31" lastStatus="Synchronized" />
+          <channel id="32" lastStatus="Synchronized" />
+          <channel id="33" lastStatus="Synchronized" />
+          <channel id="34" lastStatus="Synchronized" />
+          <channel id="35" lastStatus="Synchronized" />
+          <channel id="36" lastStatus="Synchronized" />
+          <channel id="37" lastStatus="Synchronized" />
+          <channel id="38" lastStatus="Synchronized" />
+          <channel id="39" lastStatus="Synchronized" />
+          <channel id="40" lastStatus="Synchronized" />
+          <channel id="41" lastStatus="Synchronized" />
+          <channel id="42" lastStatus="Synchronized" />
+          <channel id="43" lastStatus="Synchronized" />
+          <channel id="44" lastStatus="Synchronized" />
+          <channel id="45" lastStatus="Synchronized" />
+          <channel id="46" lastStatus="Synchronized" />
+          <channel id="47" lastStatus="Synchronized" />
+          <channel id="48" lastStatus="Synchronized" />
+          <channel id="49" lastStatus="Synchronized" />
+          <channel id="50" lastStatus="Synchronized" />
+          <channel id="51" lastStatus="Synchronized" />
+          <channel id="52" lastStatus="Synchronized" />
+          <channel id="53" lastStatus="Synchronized" />
+          <channel id="54" lastStatus="Synchronized" />
+          <channel id="55" lastStatus="Synchronized" />
+          <channel id="56" lastStatus="Synchronized" />
+          <channel id="57" lastStatus="Synchronized" />
+          <channel id="58" lastStatus="Synchronized" />
+          <channel id="59" lastStatus="Synchronized" />
+          <channel id="60" lastStatus="Synchronized" />
+          <channel id="61" lastStatus="Synchronized" />
+          <channel id="62" lastStatus="Synchronized" />
+          <channel id="63" lastStatus="Synchronized" />
+          <channel id="64" lastStatus="Synchronized" />
+          <channel id="65" lastStatus="Synchronized" />
+          <channel id="66" lastStatus="Synchronized" />
+          <channel id="67" lastStatus="Synchronized" />
+          <channel id="68" lastStatus="Synchronized" />
+          <channel id="69" lastStatus="Synchronized" />
+          <channel id="70" lastStatus="Synchronized" />
+          <channel id="71" lastStatus="Synchronized" />
+          <channel id="72" lastStatus="Synchronized" />
+          <channel id="73" lastStatus="Synchronized" />
+          <channel id="74" lastStatus="Synchronized" />
+          <channel id="75" lastStatus="Synchronized" />
+          <channel id="76" lastStatus="Synchronized" />
+          <channel id="77" lastStatus="Synchronized" />
+          <channel id="78" lastStatus="Synchronized" />
+          <channel id="79" lastStatus="Synchronized" />
+          <channel id="80" lastStatus="Synchronized" />
+          <channel id="81" lastStatus="Synchronized" />
+          <channel id="82" lastStatus="Synchronized" />
+          <channel id="83" lastStatus="Synchronized" />
+          <channel id="84" lastStatus="Synchronized" />
+          <channel id="85" lastStatus="Synchronized" />
+          <channel id="86" lastStatus="Synchronized" />
+          <channel id="87" lastStatus="Synchronized" />
+          <channel id="88" lastStatus="Synchronized" />
+          <channel id="89" lastStatus="Synchronized" />
+          <channel id="90" lastStatus="Synchronized" />
+          <channel id="91" lastStatus="Synchronized" />
+          <channel id="92" lastStatus="Synchronized" />
+          <channel id="93" lastStatus="Synchronized" />
+          <channel id="94" lastStatus="Synchronized" />
+          <channel id="95" lastStatus="Synchronized" />
+          <channel id="96" lastStatus="Synchronized" />
+          <channel id="97" lastStatus="Synchronized" />
+          <channel id="98" lastStatus="Synchronized" />
+          <channel id="99" lastStatus="Synchronized" />
+          <channel id="100" lastStatus="Synchronized" />
+          <channel id="101" lastStatus="Synchronized" />
+          <channel id="102" lastStatus="Synchronized" />
+          <channel id="103" lastStatus="Synchronized" />
+          <channel id="104" lastStatus="Synchronized" />
+          <channel id="105" lastStatus="Synchronized" />
+          <channel id="106" lastStatus="Synchronized" />
+          <channel id="107" lastStatus="Synchronized" />
+          <channel id="108" lastStatus="Synchronized" />
+          <channel id="109" lastStatus="Synchronized" />
+          <channel id="110" lastStatus="Synchronized" />
+          <channel id="111" lastStatus="Synchronized" />
+          <channel id="112" lastStatus="Synchronized" />
+          <channel id="113" lastStatus="Synchronized" />
+          <channel id="114" lastStatus="Synchronized" />
+          <channel id="115" lastStatus="Synchronized" />
+          <channel id="116" lastStatus="Synchronized" />
+          <channel id="117" lastStatus="Synchronized" />
+          <channel id="118" lastStatus="Synchronized" />
+          <channel id="119" lastStatus="Synchronized" />
+          <channel id="120" lastStatus="Synchronized" />
+          <channel id="121" lastStatus="Synchronized" />
+          <channel id="122" lastStatus="Synchronized" />
+          <channel id="123" lastStatus="Synchronized" />
+          <channel id="124" lastStatus="Synchronized" />
+          <channel id="125" lastStatus="Synchronized" />
+          <channel id="126" lastStatus="Synchronized" />
+          <channel id="127" lastStatus="Synchronized" />
+          <channel id="128" lastStatus="Synchronized" />
+          <channel id="129" lastStatus="Synchronized" />
+          <channel id="130" lastStatus="Synchronized" />
+          <channel id="131" lastStatus="Synchronized" />
+          <channel id="132" lastStatus="Synchronized" />
+          <channel id="133" lastStatus="Synchronized" />
+          <channel id="134" lastStatus="Synchronized" />
+          <channel id="135" lastStatus="Synchronized" />
+          <channel id="136" lastStatus="Synchronized" />
+          <channel id="137" lastStatus="Synchronized" />
+          <channel id="138" lastStatus="Synchronized" />
+          <channel id="139" lastStatus="Synchronized" />
+          <channel id="140" lastStatus="Synchronized" />
+          <channel id="141" lastStatus="Synchronized" />
+          <channel id="142" lastStatus="Synchronized" />
+          <channel id="143" lastStatus="Synchronized" />
+          <channel id="144" lastStatus="Synchronized" />
+          <channel id="145" lastStatus="Synchronized" />
+          <channel id="146" lastStatus="Synchronized" />
+          <channel id="147" lastStatus="Synchronized" />
+          <channel id="148" lastStatus="Synchronized" />
+          <channel id="149" lastStatus="Synchronized" />
+          <channel id="150" lastStatus="Synchronized" />
+          <channel id="151" lastStatus="Synchronized" />
+          <channel id="152" lastStatus="Synchronized" />
+          <channel id="153" lastStatus="Synchronized" />
+          <channel id="154" lastStatus="Synchronized" />
+          <channel id="155" lastStatus="Synchronized" />
+          <channel id="156" lastStatus="Synchronized" />
+          <channel id="157" lastStatus="Synchronized" />
+          <channel id="158" lastStatus="Synchronized" />
+          <channel id="159" lastStatus="Synchronized" />
+          <channel id="160" lastStatus="Synchronized" />
+          <channel id="161" lastStatus="Synchronized" />
+          <channel id="162" lastStatus="Synchronized" />
+          <channel id="163" lastStatus="Synchronized" />
+          <channel id="164" lastStatus="Synchronized" />
+          <channel id="165" lastStatus="Synchronized" />
+          <channel id="166" lastStatus="Synchronized" />
+          <channel id="167" lastStatus="Synchronized" />
+          <channel id="168" lastStatus="Synchronized" />
+          <channel id="169" lastStatus="Synchronized" />
+          <channel id="170" lastStatus="Synchronized" />
+          <channel id="171" lastStatus="Synchronized" />
+          <channel id="172" lastStatus="Synchronized" />
+          <channel id="173" lastStatus="Synchronized" />
+          <channel id="174" lastStatus="Synchronized" />
+          <channel id="175" lastStatus="Synchronized" />
+          <channel id="176" lastStatus="Synchronized" />
+          <channel id="177" lastStatus="Synchronized" />
+          <channel id="178" lastStatus="Synchronized" />
+          <channel id="179" lastStatus="Synchronized" />
+          <channel id="180" lastStatus="Synchronized" />
+          <channel id="181" lastStatus="Synchronized" />
+          <channel id="182" lastStatus="Synchronized" />
+          <channel id="183" lastStatus="Synchronized" />
+          <channel id="184" lastStatus="Synchronized" />
+          <channel id="185" lastStatus="Synchronized" />
+          <channel id="186" lastStatus="Synchronized" />
+          <channel id="187" lastStatus="Synchronized" />
+          <channel id="188" lastStatus="Synchronized" />
+          <channel id="189" lastStatus="Synchronized" />
+          <channel id="190" lastStatus="Synchronized" />
+          <channel id="191" lastStatus="Synchronized" />
+          <channel id="192" lastStatus="Synchronized" />
+          <channel id="193" lastStatus="Synchronized" />
+          <channel id="194" lastStatus="Synchronized" />
+          <channel id="195" lastStatus="Synchronized" />
+          <channel id="196" lastStatus="Synchronized" />
+          <channel id="197" lastStatus="Synchronized" />
+          <channel id="198" lastStatus="Synchronized" />
+          <channel id="199" lastStatus="Synchronized" />
+          <channel id="200" lastStatus="Synchronized" />
+          <channel id="201" lastStatus="Synchronized" />
+          <channel id="202" lastStatus="Synchronized" />
+          <channel id="203" lastStatus="Synchronized" />
+          <channel id="204" lastStatus="Synchronized" />
+          <channel id="205" lastStatus="Synchronized" />
+          <channel id="206" lastStatus="Synchronized" />
+          <channel id="207" lastStatus="Synchronized" />
+          <channel id="208" lastStatus="Synchronized" />
+          <channel id="209" lastStatus="Synchronized" />
+          <channel id="210" lastStatus="Synchronized" />
+          <channel id="211" lastStatus="Synchronized" />
+          <channel id="212" lastStatus="Synchronized" />
+          <channel id="213" lastStatus="Synchronized" />
+          <channel id="214" lastStatus="Synchronized" />
+          <channel id="215" lastStatus="Synchronized" />
+          <channel id="216" lastStatus="Synchronized" />
+          <channel id="217" lastStatus="Synchronized" />
+          <channel id="218" lastStatus="Synchronized" />
+          <channel id="219" lastStatus="Synchronized" />
+          <channel id="220" lastStatus="Synchronized" />
+          <channel id="221" lastStatus="Synchronized" />
+          <channel id="222" lastStatus="Synchronized" />
+          <channel id="223" lastStatus="Synchronized" />
+          <channel id="224" lastStatus="Synchronized" />
+          <channel id="225" lastStatus="Synchronized" />
+          <channel id="226" lastStatus="Synchronized" />
+          <channel id="227" lastStatus="Synchronized" />
+          <channel id="228" lastStatus="Synchronized" />
+          <channel id="229" lastStatus="Synchronized" />
+          <channel id="230" lastStatus="Synchronized" />
+          <channel id="231" lastStatus="Synchronized" />
+          <channel id="232" lastStatus="Synchronized" />
+          <channel id="233" lastStatus="Synchronized" />
+          <channel id="234" lastStatus="Synchronized" />
+          <channel id="235" lastStatus="Synchronized" />
+          <channel id="236" lastStatus="Synchronized" />
+          <channel id="237" lastStatus="Synchronized" />
+          <channel id="238" lastStatus="Synchronized" />
+          <channel id="239" lastStatus="Synchronized" />
+          <channel id="240" lastStatus="Synchronized" />
+          <channel id="241" lastStatus="Synchronized" />
+          <channel id="242" lastStatus="Synchronized" />
+          <channel id="243" lastStatus="Synchronized" />
+          <channel id="244" lastStatus="Synchronized" />
+          <channel id="245" lastStatus="Synchronized" />
+          <channel id="246" lastStatus="Synchronized" />
+          <channel id="247" lastStatus="Synchronized" />
+          <channel id="248" lastStatus="Synchronized" />
+          <channel id="249" lastStatus="Synchronized" />
+          <channel id="250" lastStatus="Synchronized" />
+          <channel id="251" lastStatus="Synchronized" />
+          <channel id="252" lastStatus="Synchronized" />
+          <channel id="253" lastStatus="Synchronized" />
+          <channel id="254" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:13:42 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="11.11.11" category="1" subcategory="65" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="-1" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc04DCS" displayName="Keypad - Sink" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized">
+            <onMask>
+              <device value="2" lastUpdate="12/19/2024 10:13:35 AM" />
+            </onMask>
+            <onLevel>
+              <device value="255" lastUpdate="12/19/2024 10:13:35 AM" />
+            </onLevel>
+            <rampRate>
+              <device value="28" lastUpdate="12/19/2024 10:13:35 AM" />
+            </rampRate>
+          </channel>
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 11:04:40 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="153239835" />
+          </record>
+          <record sequence="1">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3422902834" />
+          </record>
+          <record sequence="2">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="288318048" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="1532113370" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="2027693251" />
+          </record>
+          <record sequence="5">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3803169358" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="1046786131" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="356120718" />
+          </record>
+          <record sequence="8">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="2364546963" />
+          </record>
+          <record sequence="9">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="943266660" />
+          </record>
+          <record sequence="10">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3846168585" />
+          </record>
+          <record sequence="11">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="1480671700" />
+          </record>
+          <record sequence="12">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="1368183546" />
+          </record>
+          <record sequence="13">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3035674208" />
+          </record>
+          <record sequence="14">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="2248335419" />
+          </record>
+          <record sequence="15">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3197168810" />
+          </record>
+          <record sequence="16">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="798978329" />
+          </record>
+          <record sequence="17">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="1325247071" />
+          </record>
+          <record sequence="18">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3590981323" />
+          </record>
+          <record sequence="19">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3916920783" />
+          </record>
+          <record sequence="20">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3380914991" />
+          </record>
+          <record sequence="21">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3239312937" />
+          </record>
+          <record sequence="22">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3809891253" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3849306870" />
+          </record>
+          <record sequence="24">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="2191986306" />
+          </record>
+          <record sequence="25">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="379073835" />
+          </record>
+          <record sequence="26">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="4064844384" />
+          </record>
+          <record sequence="27">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="468962577" />
+          </record>
+          <record sequence="28">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="417251645" />
+          </record>
+          <record sequence="29">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3111377326" />
+          </record>
+          <record sequence="30">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="1470015737" />
+          </record>
+          <record sequence="31">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3248977371" />
+          </record>
+          <record sequence="32">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="1802163777" />
+          </record>
+          <record sequence="33">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3929922712" />
+          </record>
+          <record sequence="34">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3962420010" />
+          </record>
+          <record sequence="35">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="1227735179" />
+          </record>
+          <record sequence="36">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="2809314202" />
+          </record>
+          <record sequence="37">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3382130665" />
+          </record>
+          <record sequence="38">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="2708729408" />
+          </record>
+          <record sequence="39">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="2704670422" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized">
+          <p name="operatingFlags">
+            <device value="0x80" lastUpdate="12/19/2024 10:13:35 AM" />
+          </p>
+        </properties>
+      </device>
+      <device insteonID="22.22.22" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="100" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Cove Lighting" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/19/2024 11:04:40 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="164402797" />
+          </record>
+          <record sequence="1">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="1294403059" />
+          </record>
+          <record sequence="2">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="3620933688" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="76276406" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2881720383" />
+          </record>
+          <record sequence="5">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="3352794293" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="2744904854" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1081503" />
+          </record>
+          <record sequence="8">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="2225941200" />
+          </record>
+          <record sequence="9">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1189343867" />
+          </record>
+          <record sequence="10">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2929919737" />
+          </record>
+          <record sequence="11">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="515450109" />
+          </record>
+          <record sequence="12">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="3483277612" />
+          </record>
+          <record sequence="13">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2523956666" />
+          </record>
+          <record sequence="14">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="751552240" />
+          </record>
+          <record sequence="15">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="39960775" />
+          </record>
+          <record sequence="16">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1593359211" />
+          </record>
+          <record sequence="17">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="3817997440" />
+          </record>
+          <record sequence="18">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="3632613276" />
+          </record>
+          <record sequence="19">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="1346764324" />
+          </record>
+          <record sequence="20">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2250912993" />
+          </record>
+          <record sequence="21">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="3747120858" />
+          </record>
+          <record sequence="22">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="1808260376" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2408604460" />
+          </record>
+          <record sequence="24">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1826940464" />
+          </record>
+          <record sequence="25">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="2521921366" />
+          </record>
+          <record sequence="26">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1159424975" />
+          </record>
+          <record sequence="27">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="3436235587" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized">
+          <p name="operatingFlags">
+            <device value="0x80" lastUpdate="12/19/2024 10:13:35 AM" />
+          </p>
+        </properties>
+      </device>
+      <device insteonID="33.33.33" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="20" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Island Cans" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/19/2024 11:04:40 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="826194698" />
+          </record>
+          <record sequence="1">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="769512099" />
+          </record>
+          <record sequence="2">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2631277828" />
+          </record>
+          <record sequence="3">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="1414069123" />
+          </record>
+          <record sequence="4">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="3152810492" />
+          </record>
+          <record sequence="5">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2635434951" />
+          </record>
+          <record sequence="6">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="4004517134" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="897946518" />
+          </record>
+          <record sequence="8">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="3304652418" />
+          </record>
+          <record sequence="9">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2773947999" />
+          </record>
+          <record sequence="10">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2557239114" />
+          </record>
+          <record sequence="11">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2779344193" />
+          </record>
+          <record sequence="12">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="1246774102" />
+          </record>
+          <record sequence="13">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="3473016110" />
+          </record>
+          <record sequence="14">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="263461420" />
+          </record>
+          <record sequence="15">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="152069077" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="44.44.44" category="1" subcategory="65" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="20" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc04DCS" displayName="Keypad - Stove Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 11:04:40 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3350787379" />
+          </record>
+          <record sequence="1">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="4087967961" />
+          </record>
+          <record sequence="2">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="51487738" />
+          </record>
+          <record sequence="3">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3142774219" />
+          </record>
+          <record sequence="4">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="1996605221" />
+          </record>
+          <record sequence="5">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="1959111034" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="282612497" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2781955440" />
+          </record>
+          <record sequence="8">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3262628121" />
+          </record>
+          <record sequence="9">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="2590255222" />
+          </record>
+          <record sequence="10">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2571491210" />
+          </record>
+          <record sequence="11">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3964476100" />
+          </record>
+          <record sequence="12">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="45737954" />
+          </record>
+          <record sequence="13">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="4196016352" />
+          </record>
+          <record sequence="14">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="199642022" />
+          </record>
+          <record sequence="15">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="4211626962" />
+          </record>
+          <record sequence="16">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2514296288" />
+          </record>
+          <record sequence="17">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3697521159" />
+          </record>
+          <record sequence="18">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="2603900541" />
+          </record>
+          <record sequence="19">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="206552202" />
+          </record>
+          <record sequence="20">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="850407712" />
+          </record>
+          <record sequence="21">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="2330772681" />
+          </record>
+          <record sequence="22">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2057644997" />
+          </record>
+          <record sequence="23">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2518671397" />
+          </record>
+          <record sequence="24">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="1468329277" />
+          </record>
+          <record sequence="25">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="993388565" />
+          </record>
+          <record sequence="26">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2840873367" />
+          </record>
+          <record sequence="27">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3076418730" />
+          </record>
+          <record sequence="28">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2186245660" />
+          </record>
+          <record sequence="29">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2453929577" />
+          </record>
+          <record sequence="30">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3977659963" />
+          </record>
+          <record sequence="31">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2731998862" />
+          </record>
+          <record sequence="32">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="1813322657" />
+          </record>
+          <record sequence="33">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3764318011" />
+          </record>
+          <record sequence="34">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3474631450" />
+          </record>
+          <record sequence="35">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3064685202" />
+          </record>
+          <record sequence="36">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="189491713" />
+          </record>
+          <record sequence="37">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="3155725610" />
+          </record>
+          <record sequence="38">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="115406504" />
+          </record>
+          <record sequence="39">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="1153684263" />
+          </record>
+          <record sequence="40">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="1099224173" />
+          </record>
+          <record sequence="41">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="410608252" />
+          </record>
+          <record sequence="42">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3897768486" />
+          </record>
+          <record sequence="43">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="1804700244" />
+          </record>
+          <record sequence="44">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="synced" uid="2260289485" />
+          </record>
+          <record sequence="45">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="1158730727" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="55.55.55" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Ceiling Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 11:04:40 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1706056445" />
+          </record>
+          <record sequence="1">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2818746250" />
+          </record>
+          <record sequence="2">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1641301605" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2300720991" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="213552785" />
+          </record>
+          <record sequence="5">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2217758658" />
+          </record>
+          <record sequence="6">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="122513804" />
+          </record>
+          <record sequence="7">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1944693029" />
+          </record>
+          <record sequence="8">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="429858621" />
+          </record>
+          <record sequence="9">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3122335706" />
+          </record>
+          <record sequence="10">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2153423724" />
+          </record>
+          <record sequence="11">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3825008370" />
+          </record>
+          <record sequence="12">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1995529170" />
+          </record>
+          <record sequence="13">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="635833886" />
+          </record>
+          <record sequence="14">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2822527601" />
+          </record>
+          <record sequence="15">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2041695386" />
+          </record>
+          <record sequence="16">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1459352785" />
+          </record>
+          <record sequence="17">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3095619418" />
+          </record>
+          <record sequence="18">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="323132048" />
+          </record>
+          <record sequence="19">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3265053426" />
+          </record>
+          <record sequence="20">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3458335817" />
+          </record>
+          <record sequence="21">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1983534218" />
+          </record>
+          <record sequence="22">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3348750453" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1236220472" />
+          </record>
+          <record sequence="24">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="432819161" />
+          </record>
+          <record sequence="25">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1705634178" />
+          </record>
+          <record sequence="26">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2323067757" />
+          </record>
+          <record sequence="27">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2140353593" />
+          </record>
+          <record sequence="28">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="740627246" />
+          </record>
+          <record sequence="29">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="4066165554" />
+          </record>
+          <record sequence="30">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3362706785" />
+          </record>
+          <record sequence="31">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3221708381" />
+          </record>
+          <record sequence="32">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3503986454" />
+          </record>
+          <record sequence="33">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1303264596" />
+          </record>
+          <record sequence="34">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="1542211798" />
+          </record>
+          <record sequence="35">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="2840975989" />
+          </record>
+          <record sequence="36">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="604795073" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="AA.AA.AA" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Under Cabinet Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="BB.BB.BB" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Nook Ceiling Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="CC.CC.CC" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Pantry Lights" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+    </active_devices>
+    <scenes nextSceneID="2">
+      <scene id="1" name="Kitchen" lastTrigger="05/17/2014 11:02:08 AM, On" notes="Turn on kitchen main lights">
+        <members>
+          <member iid="11.11.11" group="2" controller="1" responder="1" data1="255" data2="28" data3="2" status="Done" tag="35" />
+          <member iid="22.22.22" group="1" controller="1" responder="1" data1="76" data2="28" data3="1" status="Done" tag="1" />
+          <member iid="33.33.33" group="1" responder="1" data1="153" data2="28" data3="1" status="Done" tag="1" />
+          <member iid="44.44.44" group="4" responder="1" data1="255" data2="28" data3="4" status="Done" tag="35" />
+          <member iid="55.55.55" group="6" controller="1" data1="255" data2="28" data3="6" status="Done" tag="35" />
+          <member iid="55.55.55" group="6" controller="1" data1="255" data2="28" data3="6" status="Done" tag="35" />
+          <member iid="44.44.44" group="5" responder="1" data1="76" data2="28" data3="5" status="Done" tag="33" />
+          <member iid="44.44.44" group="5" responder="1" data1="76" data2="28" data3="5" status="Done" tag="33" />
+          <member iid="11.11.11" group="3" controller="1" data1="160" data2="28" data3="3" status="Done" tag="35" />
+        </members>
+      </scene>
+    </scenes>
+  </insteon>
+</settings>

--- a/UnitTestApp/Refs/Scenes2/TestRemoveDuplicateMembers.xml
+++ b/UnitTestApp/Refs/Scenes2/TestRemoveDuplicateMembers.xml
@@ -1,0 +1,898 @@
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="2.0">
+  <application />
+  <insteon>
+    <active_gateways>
+      <gateway insteonID="AA.00.00">
+        <ip port="25105" address="10.0.0.34" />
+      </gateway>
+      <gateway insteonID="BB.00.00">
+        <ip port="25105" address="10.0.0.99" />
+      </gateway>
+    </active_gateways>
+    <active_devices>
+      <device insteonID="AA.00.00" category="3" subcategory="51" revision="165" status="connected" powerline="0" radio="0" hopIfModSyncFails="0" ipk="00.00.00" wattage="0" webDeviceID="0" webGatewayControllerGroup="0" displayName="Hub" active="1">
+        <location />
+        <channels>
+          <channel id="0" lastStatus="Synchronized" />
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+          <channel id="7" lastStatus="Synchronized" />
+          <channel id="8" lastStatus="Synchronized" />
+          <channel id="9" lastStatus="Synchronized" />
+          <channel id="10" lastStatus="Synchronized" />
+          <channel id="11" lastStatus="Synchronized" />
+          <channel id="12" lastStatus="Synchronized" />
+          <channel id="13" lastStatus="Synchronized" />
+          <channel id="14" lastStatus="Synchronized" />
+          <channel id="15" lastStatus="Synchronized" />
+          <channel id="16" lastStatus="Synchronized" />
+          <channel id="17" lastStatus="Synchronized" />
+          <channel id="18" lastStatus="Synchronized" />
+          <channel id="19" lastStatus="Synchronized" />
+          <channel id="20" lastStatus="Synchronized" />
+          <channel id="21" lastStatus="Synchronized" />
+          <channel id="22" lastStatus="Synchronized" />
+          <channel id="23" lastStatus="Synchronized" />
+          <channel id="24" lastStatus="Synchronized" />
+          <channel id="25" lastStatus="Synchronized" />
+          <channel id="26" lastStatus="Synchronized" />
+          <channel id="27" lastStatus="Synchronized" />
+          <channel id="28" lastStatus="Synchronized" />
+          <channel id="29" lastStatus="Synchronized" />
+          <channel id="30" lastStatus="Synchronized" />
+          <channel id="31" lastStatus="Synchronized" />
+          <channel id="32" lastStatus="Synchronized" />
+          <channel id="33" lastStatus="Synchronized" />
+          <channel id="34" lastStatus="Synchronized" />
+          <channel id="35" lastStatus="Synchronized" />
+          <channel id="36" lastStatus="Synchronized" />
+          <channel id="37" lastStatus="Synchronized" />
+          <channel id="38" lastStatus="Synchronized" />
+          <channel id="39" lastStatus="Synchronized" />
+          <channel id="40" lastStatus="Synchronized" />
+          <channel id="41" lastStatus="Synchronized" />
+          <channel id="42" lastStatus="Synchronized" />
+          <channel id="43" lastStatus="Synchronized" />
+          <channel id="44" lastStatus="Synchronized" />
+          <channel id="45" lastStatus="Synchronized" />
+          <channel id="46" lastStatus="Synchronized" />
+          <channel id="47" lastStatus="Synchronized" />
+          <channel id="48" lastStatus="Synchronized" />
+          <channel id="49" lastStatus="Synchronized" />
+          <channel id="50" lastStatus="Synchronized" />
+          <channel id="51" lastStatus="Synchronized" />
+          <channel id="52" lastStatus="Synchronized" />
+          <channel id="53" lastStatus="Synchronized" />
+          <channel id="54" lastStatus="Synchronized" />
+          <channel id="55" lastStatus="Synchronized" />
+          <channel id="56" lastStatus="Synchronized" />
+          <channel id="57" lastStatus="Synchronized" />
+          <channel id="58" lastStatus="Synchronized" />
+          <channel id="59" lastStatus="Synchronized" />
+          <channel id="60" lastStatus="Synchronized" />
+          <channel id="61" lastStatus="Synchronized" />
+          <channel id="62" lastStatus="Synchronized" />
+          <channel id="63" lastStatus="Synchronized" />
+          <channel id="64" lastStatus="Synchronized" />
+          <channel id="65" lastStatus="Synchronized" />
+          <channel id="66" lastStatus="Synchronized" />
+          <channel id="67" lastStatus="Synchronized" />
+          <channel id="68" lastStatus="Synchronized" />
+          <channel id="69" lastStatus="Synchronized" />
+          <channel id="70" lastStatus="Synchronized" />
+          <channel id="71" lastStatus="Synchronized" />
+          <channel id="72" lastStatus="Synchronized" />
+          <channel id="73" lastStatus="Synchronized" />
+          <channel id="74" lastStatus="Synchronized" />
+          <channel id="75" lastStatus="Synchronized" />
+          <channel id="76" lastStatus="Synchronized" />
+          <channel id="77" lastStatus="Synchronized" />
+          <channel id="78" lastStatus="Synchronized" />
+          <channel id="79" lastStatus="Synchronized" />
+          <channel id="80" lastStatus="Synchronized" />
+          <channel id="81" lastStatus="Synchronized" />
+          <channel id="82" lastStatus="Synchronized" />
+          <channel id="83" lastStatus="Synchronized" />
+          <channel id="84" lastStatus="Synchronized" />
+          <channel id="85" lastStatus="Synchronized" />
+          <channel id="86" lastStatus="Synchronized" />
+          <channel id="87" lastStatus="Synchronized" />
+          <channel id="88" lastStatus="Synchronized" />
+          <channel id="89" lastStatus="Synchronized" />
+          <channel id="90" lastStatus="Synchronized" />
+          <channel id="91" lastStatus="Synchronized" />
+          <channel id="92" lastStatus="Synchronized" />
+          <channel id="93" lastStatus="Synchronized" />
+          <channel id="94" lastStatus="Synchronized" />
+          <channel id="95" lastStatus="Synchronized" />
+          <channel id="96" lastStatus="Synchronized" />
+          <channel id="97" lastStatus="Synchronized" />
+          <channel id="98" lastStatus="Synchronized" />
+          <channel id="99" lastStatus="Synchronized" />
+          <channel id="100" lastStatus="Synchronized" />
+          <channel id="101" lastStatus="Synchronized" />
+          <channel id="102" lastStatus="Synchronized" />
+          <channel id="103" lastStatus="Synchronized" />
+          <channel id="104" lastStatus="Synchronized" />
+          <channel id="105" lastStatus="Synchronized" />
+          <channel id="106" lastStatus="Synchronized" />
+          <channel id="107" lastStatus="Synchronized" />
+          <channel id="108" lastStatus="Synchronized" />
+          <channel id="109" lastStatus="Synchronized" />
+          <channel id="110" lastStatus="Synchronized" />
+          <channel id="111" lastStatus="Synchronized" />
+          <channel id="112" lastStatus="Synchronized" />
+          <channel id="113" lastStatus="Synchronized" />
+          <channel id="114" lastStatus="Synchronized" />
+          <channel id="115" lastStatus="Synchronized" />
+          <channel id="116" lastStatus="Synchronized" />
+          <channel id="117" lastStatus="Synchronized" />
+          <channel id="118" lastStatus="Synchronized" />
+          <channel id="119" lastStatus="Synchronized" />
+          <channel id="120" lastStatus="Synchronized" />
+          <channel id="121" lastStatus="Synchronized" />
+          <channel id="122" lastStatus="Synchronized" />
+          <channel id="123" lastStatus="Synchronized" />
+          <channel id="124" lastStatus="Synchronized" />
+          <channel id="125" lastStatus="Synchronized" />
+          <channel id="126" lastStatus="Synchronized" />
+          <channel id="127" lastStatus="Synchronized" />
+          <channel id="128" lastStatus="Synchronized" />
+          <channel id="129" lastStatus="Synchronized" />
+          <channel id="130" lastStatus="Synchronized" />
+          <channel id="131" lastStatus="Synchronized" />
+          <channel id="132" lastStatus="Synchronized" />
+          <channel id="133" lastStatus="Synchronized" />
+          <channel id="134" lastStatus="Synchronized" />
+          <channel id="135" lastStatus="Synchronized" />
+          <channel id="136" lastStatus="Synchronized" />
+          <channel id="137" lastStatus="Synchronized" />
+          <channel id="138" lastStatus="Synchronized" />
+          <channel id="139" lastStatus="Synchronized" />
+          <channel id="140" lastStatus="Synchronized" />
+          <channel id="141" lastStatus="Synchronized" />
+          <channel id="142" lastStatus="Synchronized" />
+          <channel id="143" lastStatus="Synchronized" />
+          <channel id="144" lastStatus="Synchronized" />
+          <channel id="145" lastStatus="Synchronized" />
+          <channel id="146" lastStatus="Synchronized" />
+          <channel id="147" lastStatus="Synchronized" />
+          <channel id="148" lastStatus="Synchronized" />
+          <channel id="149" lastStatus="Synchronized" />
+          <channel id="150" lastStatus="Synchronized" />
+          <channel id="151" lastStatus="Synchronized" />
+          <channel id="152" lastStatus="Synchronized" />
+          <channel id="153" lastStatus="Synchronized" />
+          <channel id="154" lastStatus="Synchronized" />
+          <channel id="155" lastStatus="Synchronized" />
+          <channel id="156" lastStatus="Synchronized" />
+          <channel id="157" lastStatus="Synchronized" />
+          <channel id="158" lastStatus="Synchronized" />
+          <channel id="159" lastStatus="Synchronized" />
+          <channel id="160" lastStatus="Synchronized" />
+          <channel id="161" lastStatus="Synchronized" />
+          <channel id="162" lastStatus="Synchronized" />
+          <channel id="163" lastStatus="Synchronized" />
+          <channel id="164" lastStatus="Synchronized" />
+          <channel id="165" lastStatus="Synchronized" />
+          <channel id="166" lastStatus="Synchronized" />
+          <channel id="167" lastStatus="Synchronized" />
+          <channel id="168" lastStatus="Synchronized" />
+          <channel id="169" lastStatus="Synchronized" />
+          <channel id="170" lastStatus="Synchronized" />
+          <channel id="171" lastStatus="Synchronized" />
+          <channel id="172" lastStatus="Synchronized" />
+          <channel id="173" lastStatus="Synchronized" />
+          <channel id="174" lastStatus="Synchronized" />
+          <channel id="175" lastStatus="Synchronized" />
+          <channel id="176" lastStatus="Synchronized" />
+          <channel id="177" lastStatus="Synchronized" />
+          <channel id="178" lastStatus="Synchronized" />
+          <channel id="179" lastStatus="Synchronized" />
+          <channel id="180" lastStatus="Synchronized" />
+          <channel id="181" lastStatus="Synchronized" />
+          <channel id="182" lastStatus="Synchronized" />
+          <channel id="183" lastStatus="Synchronized" />
+          <channel id="184" lastStatus="Synchronized" />
+          <channel id="185" lastStatus="Synchronized" />
+          <channel id="186" lastStatus="Synchronized" />
+          <channel id="187" lastStatus="Synchronized" />
+          <channel id="188" lastStatus="Synchronized" />
+          <channel id="189" lastStatus="Synchronized" />
+          <channel id="190" lastStatus="Synchronized" />
+          <channel id="191" lastStatus="Synchronized" />
+          <channel id="192" lastStatus="Synchronized" />
+          <channel id="193" lastStatus="Synchronized" />
+          <channel id="194" lastStatus="Synchronized" />
+          <channel id="195" lastStatus="Synchronized" />
+          <channel id="196" lastStatus="Synchronized" />
+          <channel id="197" lastStatus="Synchronized" />
+          <channel id="198" lastStatus="Synchronized" />
+          <channel id="199" lastStatus="Synchronized" />
+          <channel id="200" lastStatus="Synchronized" />
+          <channel id="201" lastStatus="Synchronized" />
+          <channel id="202" lastStatus="Synchronized" />
+          <channel id="203" lastStatus="Synchronized" />
+          <channel id="204" lastStatus="Synchronized" />
+          <channel id="205" lastStatus="Synchronized" />
+          <channel id="206" lastStatus="Synchronized" />
+          <channel id="207" lastStatus="Synchronized" />
+          <channel id="208" lastStatus="Synchronized" />
+          <channel id="209" lastStatus="Synchronized" />
+          <channel id="210" lastStatus="Synchronized" />
+          <channel id="211" lastStatus="Synchronized" />
+          <channel id="212" lastStatus="Synchronized" />
+          <channel id="213" lastStatus="Synchronized" />
+          <channel id="214" lastStatus="Synchronized" />
+          <channel id="215" lastStatus="Synchronized" />
+          <channel id="216" lastStatus="Synchronized" />
+          <channel id="217" lastStatus="Synchronized" />
+          <channel id="218" lastStatus="Synchronized" />
+          <channel id="219" lastStatus="Synchronized" />
+          <channel id="220" lastStatus="Synchronized" />
+          <channel id="221" lastStatus="Synchronized" />
+          <channel id="222" lastStatus="Synchronized" />
+          <channel id="223" lastStatus="Synchronized" />
+          <channel id="224" lastStatus="Synchronized" />
+          <channel id="225" lastStatus="Synchronized" />
+          <channel id="226" lastStatus="Synchronized" />
+          <channel id="227" lastStatus="Synchronized" />
+          <channel id="228" lastStatus="Synchronized" />
+          <channel id="229" lastStatus="Synchronized" />
+          <channel id="230" lastStatus="Synchronized" />
+          <channel id="231" lastStatus="Synchronized" />
+          <channel id="232" lastStatus="Synchronized" />
+          <channel id="233" lastStatus="Synchronized" />
+          <channel id="234" lastStatus="Synchronized" />
+          <channel id="235" lastStatus="Synchronized" />
+          <channel id="236" lastStatus="Synchronized" />
+          <channel id="237" lastStatus="Synchronized" />
+          <channel id="238" lastStatus="Synchronized" />
+          <channel id="239" lastStatus="Synchronized" />
+          <channel id="240" lastStatus="Synchronized" />
+          <channel id="241" lastStatus="Synchronized" />
+          <channel id="242" lastStatus="Synchronized" />
+          <channel id="243" lastStatus="Synchronized" />
+          <channel id="244" lastStatus="Synchronized" />
+          <channel id="245" lastStatus="Synchronized" />
+          <channel id="246" lastStatus="Synchronized" />
+          <channel id="247" lastStatus="Synchronized" />
+          <channel id="248" lastStatus="Synchronized" />
+          <channel id="249" lastStatus="Synchronized" />
+          <channel id="250" lastStatus="Synchronized" />
+          <channel id="251" lastStatus="Synchronized" />
+          <channel id="252" lastStatus="Synchronized" />
+          <channel id="253" lastStatus="Synchronized" />
+          <channel id="254" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:13:42 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="11.11.11" category="1" subcategory="65" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="-1" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc04DCS" displayName="Keypad - Sink" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized">
+            <onMask>
+              <device value="2" lastUpdate="12/19/2024 10:13:35 AM" />
+            </onMask>
+            <onLevel>
+              <device value="255" lastUpdate="12/19/2024 10:13:35 AM" />
+            </onLevel>
+            <rampRate>
+              <device value="28" lastUpdate="12/19/2024 10:13:35 AM" />
+            </rampRate>
+          </channel>
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 6:02:50 PM" lastStatus="Changed" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="153239835" />
+          </record>
+          <record sequence="1">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3422902834" />
+          </record>
+          <record sequence="2">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="1634434460" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="391791943" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="2890886414" />
+          </record>
+          <record sequence="5">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3803169358" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="976426833" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="3949688230" />
+          </record>
+          <record sequence="8">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="2364546963" />
+          </record>
+          <record sequence="9">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="943266660" />
+          </record>
+          <record sequence="10">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="2766418494" />
+          </record>
+          <record sequence="11">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="141281364" />
+          </record>
+          <record sequence="12">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="1785897471" />
+          </record>
+          <record sequence="13">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3035674208" />
+          </record>
+          <record sequence="14">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="2248335419" />
+          </record>
+          <record sequence="15">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="2847390684" />
+          </record>
+          <record sequence="16">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="3023783691" />
+          </record>
+          <record sequence="17">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="1781713922" />
+          </record>
+          <record sequence="18">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3590981323" />
+          </record>
+          <record sequence="19">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="2300234846" />
+          </record>
+          <record sequence="20">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="3101011026" />
+          </record>
+          <record sequence="21">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3239312937" />
+          </record>
+          <record sequence="22">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3809891253" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="281492117" />
+          </record>
+          <record sequence="24">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="612314178" />
+          </record>
+          <record sequence="25">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="37932241" />
+          </record>
+          <record sequence="26">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="4064844384" />
+          </record>
+          <record sequence="27">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="468962577" />
+          </record>
+          <record sequence="28">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="3610899249" />
+          </record>
+          <record sequence="29">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="3023536447" />
+          </record>
+          <record sequence="30">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="2737937362" />
+          </record>
+          <record sequence="31">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3248977371" />
+          </record>
+          <record sequence="32">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="3864348104" />
+          </record>
+          <record sequence="33">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="2354218281" />
+          </record>
+          <record sequence="34">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3962420010" />
+          </record>
+          <record sequence="35">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="1227735179" />
+          </record>
+          <record sequence="36">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="1746064743" />
+          </record>
+          <record sequence="37">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="4049552499" />
+          </record>
+          <record sequence="38">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="1258842097" />
+          </record>
+          <record sequence="39">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="2704670422" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized">
+          <p name="operatingFlags">
+            <device value="0x80" lastUpdate="12/19/2024 10:13:35 AM" />
+          </p>
+        </properties>
+      </device>
+      <device insteonID="22.22.22" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="100" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Cove Lighting" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/19/2024 6:02:50 PM" lastStatus="Changed" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="164402797" />
+          </record>
+          <record sequence="1">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="1294403059" />
+          </record>
+          <record sequence="2">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="3620933688" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="3703716976" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="280297621" />
+          </record>
+          <record sequence="5">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="1627936002" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="1208092500" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="3504312231" />
+          </record>
+          <record sequence="8">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="2225941200" />
+          </record>
+          <record sequence="9">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1189343867" />
+          </record>
+          <record sequence="10">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2929919737" />
+          </record>
+          <record sequence="11">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="515450109" />
+          </record>
+          <record sequence="12">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="1511842654" />
+          </record>
+          <record sequence="13">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="2676108415" />
+          </record>
+          <record sequence="14">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="3967192560" />
+          </record>
+          <record sequence="15">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="1544063555" />
+          </record>
+          <record sequence="16">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="1527466592" />
+          </record>
+          <record sequence="17">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="3817997440" />
+          </record>
+          <record sequence="18">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="3632613276" />
+          </record>
+          <record sequence="19">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="1346764324" />
+          </record>
+          <record sequence="20">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2250912993" />
+          </record>
+          <record sequence="21">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="2552943681" />
+          </record>
+          <record sequence="22">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="341941166" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="415512801" />
+          </record>
+          <record sequence="24">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="175498745" />
+          </record>
+          <record sequence="25">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="3740661707" />
+          </record>
+          <record sequence="26">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1159424975" />
+          </record>
+          <record sequence="27">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="3436235587" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized">
+          <p name="operatingFlags">
+            <device value="0x80" lastUpdate="12/19/2024 10:13:35 AM" />
+          </p>
+        </properties>
+      </device>
+      <device insteonID="33.33.33" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="20" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Island Cans" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/19/2024 6:02:50 PM" lastStatus="Changed" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="826194698" />
+          </record>
+          <record sequence="1">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="769512099" />
+          </record>
+          <record sequence="2">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="3551885859" />
+          </record>
+          <record sequence="3">
+            <device address="55.55.55" group="6" recordControl="34" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="2982622001" />
+          </record>
+          <record sequence="4">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="3152810492" />
+          </record>
+          <record sequence="5">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2635434951" />
+          </record>
+          <record sequence="6">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="4004517134" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="34" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="3449735591" />
+          </record>
+          <record sequence="8">
+            <device address="55.55.55" group="6" recordControl="34" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="1815999600" />
+          </record>
+          <record sequence="9">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2773947999" />
+          </record>
+          <record sequence="10">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2557239114" />
+          </record>
+          <record sequence="11">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2779344193" />
+          </record>
+          <record sequence="12">
+            <device address="55.55.55" group="6" recordControl="34" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="1795749785" />
+          </record>
+          <record sequence="13">
+            <device address="55.55.55" group="6" recordControl="34" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="3861551295" />
+          </record>
+          <record sequence="14">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="263461420" />
+          </record>
+          <record sequence="15">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="152069077" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="44.44.44" category="1" subcategory="65" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="20" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc04DCS" displayName="Keypad - Stove Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 6:02:50 PM" lastStatus="Changed" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3350787379" />
+          </record>
+          <record sequence="1">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="383151001" />
+          </record>
+          <record sequence="2">
+            <device address="11.11.11" group="2" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1166165316" />
+          </record>
+          <record sequence="3">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3142774219" />
+          </record>
+          <record sequence="4">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3013071238" />
+          </record>
+          <record sequence="5">
+            <device address="22.22.22" group="1" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="915047191" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="1996030918" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="4018824120" />
+          </record>
+          <record sequence="8">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="4090814922" />
+          </record>
+          <record sequence="9">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="674283833" />
+          </record>
+          <record sequence="10">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3953026331" />
+          </record>
+          <record sequence="11">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3744642540" />
+          </record>
+          <record sequence="12">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="45737954" />
+          </record>
+          <record sequence="13">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3855527775" />
+          </record>
+          <record sequence="14">
+            <device address="11.11.11" group="3" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="182332342" />
+          </record>
+          <record sequence="15">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="4211626962" />
+          </record>
+          <record sequence="16">
+            <device address="11.11.11" group="2" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="2393453893" />
+          </record>
+          <record sequence="17">
+            <device address="11.11.11" group="2" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3968330647" />
+          </record>
+          <record sequence="18">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="2603900541" />
+          </record>
+          <record sequence="19">
+            <device address="22.22.22" group="1" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1407178622" />
+          </record>
+          <record sequence="20">
+            <device address="22.22.22" group="1" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3446631792" />
+          </record>
+          <record sequence="21">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="3678012685" />
+          </record>
+          <record sequence="22">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1549784778" />
+          </record>
+          <record sequence="23">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="155608704" />
+          </record>
+          <record sequence="24">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="3452277312" />
+          </record>
+          <record sequence="25">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3208153933" />
+          </record>
+          <record sequence="26">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="2139358114" />
+          </record>
+          <record sequence="27">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3076418730" />
+          </record>
+          <record sequence="28">
+            <device address="11.11.11" group="3" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1466211060" />
+          </record>
+          <record sequence="29">
+            <device address="11.11.11" group="3" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1062971667" />
+          </record>
+          <record sequence="30">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3977659963" />
+          </record>
+          <record sequence="31">
+            <device address="11.11.11" group="2" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3075432850" />
+          </record>
+          <record sequence="32">
+            <device address="11.11.11" group="2" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="2170493271" />
+          </record>
+          <record sequence="33">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3764318011" />
+          </record>
+          <record sequence="34">
+            <device address="22.22.22" group="1" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="113916685" />
+          </record>
+          <record sequence="35">
+            <device address="22.22.22" group="1" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="2236535807" />
+          </record>
+          <record sequence="36">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="2576805800" />
+          </record>
+          <record sequence="37">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1487362177" />
+          </record>
+          <record sequence="38">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1760774770" />
+          </record>
+          <record sequence="39">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="1511257311" />
+          </record>
+          <record sequence="40">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3438806530" />
+          </record>
+          <record sequence="41">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3990418494" />
+          </record>
+          <record sequence="42">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3897768486" />
+          </record>
+          <record sequence="43">
+            <device address="11.11.11" group="3" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="2481339522" />
+          </record>
+          <record sequence="44">
+            <device address="11.11.11" group="3" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="4067795118" />
+          </record>
+          <record sequence="45">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="1158730727" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="55.55.55" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Ceiling Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 6:02:50 PM" lastStatus="Changed" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1206919277" />
+          </record>
+          <record sequence="1">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2906552015" />
+          </record>
+          <record sequence="2">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="793274515" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2865472380" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1688185923" />
+          </record>
+          <record sequence="5">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="4264274583" />
+          </record>
+          <record sequence="6">
+            <device address="11.11.11" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2652726427" />
+          </record>
+          <record sequence="7">
+            <device address="22.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2176063648" />
+          </record>
+          <record sequence="8">
+            <device address="33.33.33" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="305043922" />
+          </record>
+          <record sequence="9">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1117718072" />
+          </record>
+          <record sequence="10">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="58270996" />
+          </record>
+          <record sequence="11">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="3256516451" />
+          </record>
+          <record sequence="12">
+            <device address="11.11.11" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1300408116" />
+          </record>
+          <record sequence="13">
+            <device address="22.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2886580243" />
+          </record>
+          <record sequence="14">
+            <device address="33.33.33" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2991891802" />
+          </record>
+          <record sequence="15">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="3136518840" />
+          </record>
+          <record sequence="16">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2648236443" />
+          </record>
+          <record sequence="17">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="3863712273" />
+          </record>
+          <record sequence="18">
+            <device address="11.11.11" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2485562743" />
+          </record>
+          <record sequence="19">
+            <device address="22.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2357266610" />
+          </record>
+          <record sequence="20">
+            <device address="33.33.33" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="803637131" />
+          </record>
+          <record sequence="21">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2382884635" />
+          </record>
+          <record sequence="22">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2833786571" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="3171625740" />
+          </record>
+          <record sequence="24">
+            <device address="11.11.11" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2954467900" />
+          </record>
+          <record sequence="25">
+            <device address="22.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2874317539" />
+          </record>
+          <record sequence="26">
+            <device address="33.33.33" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="3310255723" />
+          </record>
+          <record sequence="27">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1650458341" />
+          </record>
+          <record sequence="28">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="694198885" />
+          </record>
+          <record sequence="29">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2519761495" />
+          </record>
+          <record sequence="30">
+            <device address="11.11.11" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="3086177025" />
+          </record>
+          <record sequence="31">
+            <device address="22.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="64173701" />
+          </record>
+          <record sequence="32">
+            <device address="33.33.33" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="4112731679" />
+          </record>
+          <record sequence="33">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1939613286" />
+          </record>
+          <record sequence="34">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2039455711" />
+          </record>
+          <record sequence="35">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="667504902" />
+          </record>
+          <record sequence="36">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="604795073" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="AA.AA.AA" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Under Cabinet Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="BB.BB.BB" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Nook Ceiling Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="CC.CC.CC" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Pantry Lights" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+    </active_devices>
+    <scenes nextSceneID="2">
+      <scene id="1" name="Kitchen" lastTrigger="05/17/2014 11:02:08 AM, On" notes="Turn on kitchen main lights">
+        <members>
+          <member iid="11.11.11" group="2" controller="1" responder="1" data1="255" data2="28" data3="2" status="Done" tag="35" />
+          <member iid="22.22.22" group="1" controller="1" responder="1" data1="76" data2="28" data3="1" status="Done" tag="1" />
+          <member iid="33.33.33" group="1" responder="1" data1="153" data2="28" data3="1" status="Done" tag="1" />
+          <member iid="44.44.44" group="4" responder="1" data1="255" data2="28" data3="4" status="Done" tag="35" />
+          <member iid="55.55.55" group="6" controller="1" data1="255" data2="28" data3="6" status="Done" tag="35" />
+          <member iid="44.44.44" group="5" responder="1" data1="76" data2="28" data3="5" status="Done" tag="33" />
+          <member iid="11.11.11" group="3" controller="1" data1="160" data2="28" data3="3" status="Done" tag="35" />
+        </members>
+      </scene>
+    </scenes>
+  </insteon>
+</settings>

--- a/UnitTestApp/Refs/Scenes2/TestRemoveDuplicateMembersOneByOne.xml
+++ b/UnitTestApp/Refs/Scenes2/TestRemoveDuplicateMembersOneByOne.xml
@@ -1,0 +1,898 @@
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="2.0">
+  <application />
+  <insteon>
+    <active_gateways>
+      <gateway insteonID="AA.00.00">
+        <ip port="25105" address="10.0.0.34" />
+      </gateway>
+      <gateway insteonID="BB.00.00">
+        <ip port="25105" address="10.0.0.99" />
+      </gateway>
+    </active_gateways>
+    <active_devices>
+      <device insteonID="AA.00.00" category="3" subcategory="51" revision="165" status="connected" powerline="0" radio="0" hopIfModSyncFails="0" ipk="00.00.00" wattage="0" webDeviceID="0" webGatewayControllerGroup="0" displayName="Hub" active="1">
+        <location />
+        <channels>
+          <channel id="0" lastStatus="Synchronized" />
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+          <channel id="7" lastStatus="Synchronized" />
+          <channel id="8" lastStatus="Synchronized" />
+          <channel id="9" lastStatus="Synchronized" />
+          <channel id="10" lastStatus="Synchronized" />
+          <channel id="11" lastStatus="Synchronized" />
+          <channel id="12" lastStatus="Synchronized" />
+          <channel id="13" lastStatus="Synchronized" />
+          <channel id="14" lastStatus="Synchronized" />
+          <channel id="15" lastStatus="Synchronized" />
+          <channel id="16" lastStatus="Synchronized" />
+          <channel id="17" lastStatus="Synchronized" />
+          <channel id="18" lastStatus="Synchronized" />
+          <channel id="19" lastStatus="Synchronized" />
+          <channel id="20" lastStatus="Synchronized" />
+          <channel id="21" lastStatus="Synchronized" />
+          <channel id="22" lastStatus="Synchronized" />
+          <channel id="23" lastStatus="Synchronized" />
+          <channel id="24" lastStatus="Synchronized" />
+          <channel id="25" lastStatus="Synchronized" />
+          <channel id="26" lastStatus="Synchronized" />
+          <channel id="27" lastStatus="Synchronized" />
+          <channel id="28" lastStatus="Synchronized" />
+          <channel id="29" lastStatus="Synchronized" />
+          <channel id="30" lastStatus="Synchronized" />
+          <channel id="31" lastStatus="Synchronized" />
+          <channel id="32" lastStatus="Synchronized" />
+          <channel id="33" lastStatus="Synchronized" />
+          <channel id="34" lastStatus="Synchronized" />
+          <channel id="35" lastStatus="Synchronized" />
+          <channel id="36" lastStatus="Synchronized" />
+          <channel id="37" lastStatus="Synchronized" />
+          <channel id="38" lastStatus="Synchronized" />
+          <channel id="39" lastStatus="Synchronized" />
+          <channel id="40" lastStatus="Synchronized" />
+          <channel id="41" lastStatus="Synchronized" />
+          <channel id="42" lastStatus="Synchronized" />
+          <channel id="43" lastStatus="Synchronized" />
+          <channel id="44" lastStatus="Synchronized" />
+          <channel id="45" lastStatus="Synchronized" />
+          <channel id="46" lastStatus="Synchronized" />
+          <channel id="47" lastStatus="Synchronized" />
+          <channel id="48" lastStatus="Synchronized" />
+          <channel id="49" lastStatus="Synchronized" />
+          <channel id="50" lastStatus="Synchronized" />
+          <channel id="51" lastStatus="Synchronized" />
+          <channel id="52" lastStatus="Synchronized" />
+          <channel id="53" lastStatus="Synchronized" />
+          <channel id="54" lastStatus="Synchronized" />
+          <channel id="55" lastStatus="Synchronized" />
+          <channel id="56" lastStatus="Synchronized" />
+          <channel id="57" lastStatus="Synchronized" />
+          <channel id="58" lastStatus="Synchronized" />
+          <channel id="59" lastStatus="Synchronized" />
+          <channel id="60" lastStatus="Synchronized" />
+          <channel id="61" lastStatus="Synchronized" />
+          <channel id="62" lastStatus="Synchronized" />
+          <channel id="63" lastStatus="Synchronized" />
+          <channel id="64" lastStatus="Synchronized" />
+          <channel id="65" lastStatus="Synchronized" />
+          <channel id="66" lastStatus="Synchronized" />
+          <channel id="67" lastStatus="Synchronized" />
+          <channel id="68" lastStatus="Synchronized" />
+          <channel id="69" lastStatus="Synchronized" />
+          <channel id="70" lastStatus="Synchronized" />
+          <channel id="71" lastStatus="Synchronized" />
+          <channel id="72" lastStatus="Synchronized" />
+          <channel id="73" lastStatus="Synchronized" />
+          <channel id="74" lastStatus="Synchronized" />
+          <channel id="75" lastStatus="Synchronized" />
+          <channel id="76" lastStatus="Synchronized" />
+          <channel id="77" lastStatus="Synchronized" />
+          <channel id="78" lastStatus="Synchronized" />
+          <channel id="79" lastStatus="Synchronized" />
+          <channel id="80" lastStatus="Synchronized" />
+          <channel id="81" lastStatus="Synchronized" />
+          <channel id="82" lastStatus="Synchronized" />
+          <channel id="83" lastStatus="Synchronized" />
+          <channel id="84" lastStatus="Synchronized" />
+          <channel id="85" lastStatus="Synchronized" />
+          <channel id="86" lastStatus="Synchronized" />
+          <channel id="87" lastStatus="Synchronized" />
+          <channel id="88" lastStatus="Synchronized" />
+          <channel id="89" lastStatus="Synchronized" />
+          <channel id="90" lastStatus="Synchronized" />
+          <channel id="91" lastStatus="Synchronized" />
+          <channel id="92" lastStatus="Synchronized" />
+          <channel id="93" lastStatus="Synchronized" />
+          <channel id="94" lastStatus="Synchronized" />
+          <channel id="95" lastStatus="Synchronized" />
+          <channel id="96" lastStatus="Synchronized" />
+          <channel id="97" lastStatus="Synchronized" />
+          <channel id="98" lastStatus="Synchronized" />
+          <channel id="99" lastStatus="Synchronized" />
+          <channel id="100" lastStatus="Synchronized" />
+          <channel id="101" lastStatus="Synchronized" />
+          <channel id="102" lastStatus="Synchronized" />
+          <channel id="103" lastStatus="Synchronized" />
+          <channel id="104" lastStatus="Synchronized" />
+          <channel id="105" lastStatus="Synchronized" />
+          <channel id="106" lastStatus="Synchronized" />
+          <channel id="107" lastStatus="Synchronized" />
+          <channel id="108" lastStatus="Synchronized" />
+          <channel id="109" lastStatus="Synchronized" />
+          <channel id="110" lastStatus="Synchronized" />
+          <channel id="111" lastStatus="Synchronized" />
+          <channel id="112" lastStatus="Synchronized" />
+          <channel id="113" lastStatus="Synchronized" />
+          <channel id="114" lastStatus="Synchronized" />
+          <channel id="115" lastStatus="Synchronized" />
+          <channel id="116" lastStatus="Synchronized" />
+          <channel id="117" lastStatus="Synchronized" />
+          <channel id="118" lastStatus="Synchronized" />
+          <channel id="119" lastStatus="Synchronized" />
+          <channel id="120" lastStatus="Synchronized" />
+          <channel id="121" lastStatus="Synchronized" />
+          <channel id="122" lastStatus="Synchronized" />
+          <channel id="123" lastStatus="Synchronized" />
+          <channel id="124" lastStatus="Synchronized" />
+          <channel id="125" lastStatus="Synchronized" />
+          <channel id="126" lastStatus="Synchronized" />
+          <channel id="127" lastStatus="Synchronized" />
+          <channel id="128" lastStatus="Synchronized" />
+          <channel id="129" lastStatus="Synchronized" />
+          <channel id="130" lastStatus="Synchronized" />
+          <channel id="131" lastStatus="Synchronized" />
+          <channel id="132" lastStatus="Synchronized" />
+          <channel id="133" lastStatus="Synchronized" />
+          <channel id="134" lastStatus="Synchronized" />
+          <channel id="135" lastStatus="Synchronized" />
+          <channel id="136" lastStatus="Synchronized" />
+          <channel id="137" lastStatus="Synchronized" />
+          <channel id="138" lastStatus="Synchronized" />
+          <channel id="139" lastStatus="Synchronized" />
+          <channel id="140" lastStatus="Synchronized" />
+          <channel id="141" lastStatus="Synchronized" />
+          <channel id="142" lastStatus="Synchronized" />
+          <channel id="143" lastStatus="Synchronized" />
+          <channel id="144" lastStatus="Synchronized" />
+          <channel id="145" lastStatus="Synchronized" />
+          <channel id="146" lastStatus="Synchronized" />
+          <channel id="147" lastStatus="Synchronized" />
+          <channel id="148" lastStatus="Synchronized" />
+          <channel id="149" lastStatus="Synchronized" />
+          <channel id="150" lastStatus="Synchronized" />
+          <channel id="151" lastStatus="Synchronized" />
+          <channel id="152" lastStatus="Synchronized" />
+          <channel id="153" lastStatus="Synchronized" />
+          <channel id="154" lastStatus="Synchronized" />
+          <channel id="155" lastStatus="Synchronized" />
+          <channel id="156" lastStatus="Synchronized" />
+          <channel id="157" lastStatus="Synchronized" />
+          <channel id="158" lastStatus="Synchronized" />
+          <channel id="159" lastStatus="Synchronized" />
+          <channel id="160" lastStatus="Synchronized" />
+          <channel id="161" lastStatus="Synchronized" />
+          <channel id="162" lastStatus="Synchronized" />
+          <channel id="163" lastStatus="Synchronized" />
+          <channel id="164" lastStatus="Synchronized" />
+          <channel id="165" lastStatus="Synchronized" />
+          <channel id="166" lastStatus="Synchronized" />
+          <channel id="167" lastStatus="Synchronized" />
+          <channel id="168" lastStatus="Synchronized" />
+          <channel id="169" lastStatus="Synchronized" />
+          <channel id="170" lastStatus="Synchronized" />
+          <channel id="171" lastStatus="Synchronized" />
+          <channel id="172" lastStatus="Synchronized" />
+          <channel id="173" lastStatus="Synchronized" />
+          <channel id="174" lastStatus="Synchronized" />
+          <channel id="175" lastStatus="Synchronized" />
+          <channel id="176" lastStatus="Synchronized" />
+          <channel id="177" lastStatus="Synchronized" />
+          <channel id="178" lastStatus="Synchronized" />
+          <channel id="179" lastStatus="Synchronized" />
+          <channel id="180" lastStatus="Synchronized" />
+          <channel id="181" lastStatus="Synchronized" />
+          <channel id="182" lastStatus="Synchronized" />
+          <channel id="183" lastStatus="Synchronized" />
+          <channel id="184" lastStatus="Synchronized" />
+          <channel id="185" lastStatus="Synchronized" />
+          <channel id="186" lastStatus="Synchronized" />
+          <channel id="187" lastStatus="Synchronized" />
+          <channel id="188" lastStatus="Synchronized" />
+          <channel id="189" lastStatus="Synchronized" />
+          <channel id="190" lastStatus="Synchronized" />
+          <channel id="191" lastStatus="Synchronized" />
+          <channel id="192" lastStatus="Synchronized" />
+          <channel id="193" lastStatus="Synchronized" />
+          <channel id="194" lastStatus="Synchronized" />
+          <channel id="195" lastStatus="Synchronized" />
+          <channel id="196" lastStatus="Synchronized" />
+          <channel id="197" lastStatus="Synchronized" />
+          <channel id="198" lastStatus="Synchronized" />
+          <channel id="199" lastStatus="Synchronized" />
+          <channel id="200" lastStatus="Synchronized" />
+          <channel id="201" lastStatus="Synchronized" />
+          <channel id="202" lastStatus="Synchronized" />
+          <channel id="203" lastStatus="Synchronized" />
+          <channel id="204" lastStatus="Synchronized" />
+          <channel id="205" lastStatus="Synchronized" />
+          <channel id="206" lastStatus="Synchronized" />
+          <channel id="207" lastStatus="Synchronized" />
+          <channel id="208" lastStatus="Synchronized" />
+          <channel id="209" lastStatus="Synchronized" />
+          <channel id="210" lastStatus="Synchronized" />
+          <channel id="211" lastStatus="Synchronized" />
+          <channel id="212" lastStatus="Synchronized" />
+          <channel id="213" lastStatus="Synchronized" />
+          <channel id="214" lastStatus="Synchronized" />
+          <channel id="215" lastStatus="Synchronized" />
+          <channel id="216" lastStatus="Synchronized" />
+          <channel id="217" lastStatus="Synchronized" />
+          <channel id="218" lastStatus="Synchronized" />
+          <channel id="219" lastStatus="Synchronized" />
+          <channel id="220" lastStatus="Synchronized" />
+          <channel id="221" lastStatus="Synchronized" />
+          <channel id="222" lastStatus="Synchronized" />
+          <channel id="223" lastStatus="Synchronized" />
+          <channel id="224" lastStatus="Synchronized" />
+          <channel id="225" lastStatus="Synchronized" />
+          <channel id="226" lastStatus="Synchronized" />
+          <channel id="227" lastStatus="Synchronized" />
+          <channel id="228" lastStatus="Synchronized" />
+          <channel id="229" lastStatus="Synchronized" />
+          <channel id="230" lastStatus="Synchronized" />
+          <channel id="231" lastStatus="Synchronized" />
+          <channel id="232" lastStatus="Synchronized" />
+          <channel id="233" lastStatus="Synchronized" />
+          <channel id="234" lastStatus="Synchronized" />
+          <channel id="235" lastStatus="Synchronized" />
+          <channel id="236" lastStatus="Synchronized" />
+          <channel id="237" lastStatus="Synchronized" />
+          <channel id="238" lastStatus="Synchronized" />
+          <channel id="239" lastStatus="Synchronized" />
+          <channel id="240" lastStatus="Synchronized" />
+          <channel id="241" lastStatus="Synchronized" />
+          <channel id="242" lastStatus="Synchronized" />
+          <channel id="243" lastStatus="Synchronized" />
+          <channel id="244" lastStatus="Synchronized" />
+          <channel id="245" lastStatus="Synchronized" />
+          <channel id="246" lastStatus="Synchronized" />
+          <channel id="247" lastStatus="Synchronized" />
+          <channel id="248" lastStatus="Synchronized" />
+          <channel id="249" lastStatus="Synchronized" />
+          <channel id="250" lastStatus="Synchronized" />
+          <channel id="251" lastStatus="Synchronized" />
+          <channel id="252" lastStatus="Synchronized" />
+          <channel id="253" lastStatus="Synchronized" />
+          <channel id="254" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:13:42 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="11.11.11" category="1" subcategory="65" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="-1" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc04DCS" displayName="Keypad - Sink" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized">
+            <onMask>
+              <device value="2" lastUpdate="12/19/2024 10:13:35 AM" />
+            </onMask>
+            <onLevel>
+              <device value="255" lastUpdate="12/19/2024 10:13:35 AM" />
+            </onLevel>
+            <rampRate>
+              <device value="28" lastUpdate="12/19/2024 10:13:35 AM" />
+            </rampRate>
+          </channel>
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/20/2024 10:38:09 AM" lastStatus="Changed" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="153239835" />
+          </record>
+          <record sequence="1">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3422902834" />
+          </record>
+          <record sequence="2">
+            <device address="44.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="2576000500" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="4125693178" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="668783888" />
+          </record>
+          <record sequence="5">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3803169358" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="1057525719" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="4047442770" />
+          </record>
+          <record sequence="8">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="2364546963" />
+          </record>
+          <record sequence="9">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="943266660" />
+          </record>
+          <record sequence="10">
+            <device address="44.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="2936679782" />
+          </record>
+          <record sequence="11">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="1822647687" />
+          </record>
+          <record sequence="12">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="1908696280" />
+          </record>
+          <record sequence="13">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="3035674208" />
+          </record>
+          <record sequence="14">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="2248335419" />
+          </record>
+          <record sequence="15">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="1105289898" />
+          </record>
+          <record sequence="16">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="272661438" />
+          </record>
+          <record sequence="17">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="3046849450" />
+          </record>
+          <record sequence="18">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3590981323" />
+          </record>
+          <record sequence="19">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="2477099593" />
+          </record>
+          <record sequence="20">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="1527150772" />
+          </record>
+          <record sequence="21">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3239312937" />
+          </record>
+          <record sequence="22">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3809891253" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="1022210192" />
+          </record>
+          <record sequence="24">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="753382061" />
+          </record>
+          <record sequence="25">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="3110800826" />
+          </record>
+          <record sequence="26">
+            <device address="22.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="4064844384" />
+          </record>
+          <record sequence="27">
+            <device address="33.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="468962577" />
+          </record>
+          <record sequence="28">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="1305176723" />
+          </record>
+          <record sequence="29">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="1032302229" />
+          </record>
+          <record sequence="30">
+            <device address="44.44.44" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="427389117" />
+          </record>
+          <record sequence="31">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3248977371" />
+          </record>
+          <record sequence="32">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="2591587788" />
+          </record>
+          <record sequence="33">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="2195463604" />
+          </record>
+          <record sequence="34">
+            <device address="22.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="3962420010" />
+          </record>
+          <record sequence="35">
+            <device address="33.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="1" syncstatus="synced" uid="1227735179" />
+          </record>
+          <record sequence="36">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="263802973" />
+          </record>
+          <record sequence="37">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="3477320426" />
+          </record>
+          <record sequence="38">
+            <device address="44.44.44" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="1" syncstatus="changed" uid="3451496999" />
+          </record>
+          <record sequence="39">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="2704670422" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized">
+          <p name="operatingFlags">
+            <device value="0x80" lastUpdate="12/19/2024 10:13:35 AM" />
+          </p>
+        </properties>
+      </device>
+      <device insteonID="22.22.22" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="100" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Cove Lighting" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/20/2024 10:38:09 AM" lastStatus="Changed" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="164402797" />
+          </record>
+          <record sequence="1">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="1294403059" />
+          </record>
+          <record sequence="2">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="3620933688" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="380857278" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="4204916410" />
+          </record>
+          <record sequence="5">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="2900674911" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="673967350" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="3234983325" />
+          </record>
+          <record sequence="8">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="2225941200" />
+          </record>
+          <record sequence="9">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1189343867" />
+          </record>
+          <record sequence="10">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2929919737" />
+          </record>
+          <record sequence="11">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="515450109" />
+          </record>
+          <record sequence="12">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="37848626" />
+          </record>
+          <record sequence="13">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="1345622932" />
+          </record>
+          <record sequence="14">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="3532721528" />
+          </record>
+          <record sequence="15">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="2955412647" />
+          </record>
+          <record sequence="16">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="1429783269" />
+          </record>
+          <record sequence="17">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="3817997440" />
+          </record>
+          <record sequence="18">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="3632613276" />
+          </record>
+          <record sequence="19">
+            <device address="11.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="1346764324" />
+          </record>
+          <record sequence="20">
+            <device address="33.33.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="1" syncstatus="synced" uid="2250912993" />
+          </record>
+          <record sequence="21">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="3623030955" />
+          </record>
+          <record sequence="22">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="3633180712" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="1" recordControl="98" data1="3" data2="28" data3="1" scene="1" syncstatus="changed" uid="311053369" />
+          </record>
+          <record sequence="24">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="2324377268" />
+          </record>
+          <record sequence="25">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="1234379289" />
+          </record>
+          <record sequence="26">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="1159424975" />
+          </record>
+          <record sequence="27">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="3436235587" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized">
+          <p name="operatingFlags">
+            <device value="0x80" lastUpdate="12/19/2024 10:13:35 AM" />
+          </p>
+        </properties>
+      </device>
+      <device insteonID="33.33.33" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="20" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Island Cans" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/20/2024 10:38:09 AM" lastStatus="Changed" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="826194698" />
+          </record>
+          <record sequence="1">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="769512099" />
+          </record>
+          <record sequence="2">
+            <device address="55.55.55" group="6" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="1985775250" />
+          </record>
+          <record sequence="3">
+            <device address="55.55.55" group="6" recordControl="34" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="2571336724" />
+          </record>
+          <record sequence="4">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="3152810492" />
+          </record>
+          <record sequence="5">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2635434951" />
+          </record>
+          <record sequence="6">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="4004517134" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="34" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="3202304189" />
+          </record>
+          <record sequence="8">
+            <device address="55.55.55" group="6" recordControl="34" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="1195447943" />
+          </record>
+          <record sequence="9">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2773947999" />
+          </record>
+          <record sequence="10">
+            <device address="11.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2557239114" />
+          </record>
+          <record sequence="11">
+            <device address="22.22.22" group="1" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="2779344193" />
+          </record>
+          <record sequence="12">
+            <device address="55.55.55" group="6" recordControl="34" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="3730600932" />
+          </record>
+          <record sequence="13">
+            <device address="55.55.55" group="6" recordControl="34" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="3079541760" />
+          </record>
+          <record sequence="14">
+            <device address="11.11.11" group="3" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="263461420" />
+          </record>
+          <record sequence="15">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="152069077" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="44.44.44" category="1" subcategory="65" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="20" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc04DCS" displayName="Keypad - Stove Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/20/2024 10:38:09 AM" lastStatus="Changed" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3350787379" />
+          </record>
+          <record sequence="1">
+            <device address="11.11.11" group="2" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="2877990256" />
+          </record>
+          <record sequence="2">
+            <device address="11.11.11" group="2" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="2600388193" />
+          </record>
+          <record sequence="3">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3142774219" />
+          </record>
+          <record sequence="4">
+            <device address="22.22.22" group="1" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1299352953" />
+          </record>
+          <record sequence="5">
+            <device address="22.22.22" group="1" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3943389106" />
+          </record>
+          <record sequence="6">
+            <device address="55.55.55" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="900535531" />
+          </record>
+          <record sequence="7">
+            <device address="55.55.55" group="6" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1435689270" />
+          </record>
+          <record sequence="8">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="4044360375" />
+          </record>
+          <record sequence="9">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="885066300" />
+          </record>
+          <record sequence="10">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3371175784" />
+          </record>
+          <record sequence="11">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1270680447" />
+          </record>
+          <record sequence="12">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="45737954" />
+          </record>
+          <record sequence="13">
+            <device address="11.11.11" group="3" recordControl="162" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3389839448" />
+          </record>
+          <record sequence="14">
+            <device address="11.11.11" group="3" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1106801166" />
+          </record>
+          <record sequence="15">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="4211626962" />
+          </record>
+          <record sequence="16">
+            <device address="11.11.11" group="2" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="2159496573" />
+          </record>
+          <record sequence="17">
+            <device address="11.11.11" group="2" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3034631954" />
+          </record>
+          <record sequence="18">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="2603900541" />
+          </record>
+          <record sequence="19">
+            <device address="22.22.22" group="1" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1865313945" />
+          </record>
+          <record sequence="20">
+            <device address="22.22.22" group="1" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3472378197" />
+          </record>
+          <record sequence="21">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="940401844" />
+          </record>
+          <record sequence="22">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="2871492688" />
+          </record>
+          <record sequence="23">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1595234224" />
+          </record>
+          <record sequence="24">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="1212203462" />
+          </record>
+          <record sequence="25">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3003615650" />
+          </record>
+          <record sequence="26">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="167844598" />
+          </record>
+          <record sequence="27">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3076418730" />
+          </record>
+          <record sequence="28">
+            <device address="11.11.11" group="3" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1232617415" />
+          </record>
+          <record sequence="29">
+            <device address="11.11.11" group="3" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3803402704" />
+          </record>
+          <record sequence="30">
+            <device address="11.11.11" group="2" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3977659963" />
+          </record>
+          <record sequence="31">
+            <device address="11.11.11" group="2" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="473159481" />
+          </record>
+          <record sequence="32">
+            <device address="11.11.11" group="2" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3037160073" />
+          </record>
+          <record sequence="33">
+            <device address="22.22.22" group="1" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3764318011" />
+          </record>
+          <record sequence="34">
+            <device address="22.22.22" group="1" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="600582071" />
+          </record>
+          <record sequence="35">
+            <device address="22.22.22" group="1" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="2007684788" />
+          </record>
+          <record sequence="36">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="752387211" />
+          </record>
+          <record sequence="37">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="2397975701" />
+          </record>
+          <record sequence="38">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3458902482" />
+          </record>
+          <record sequence="39">
+            <device address="55.55.55" group="6" recordControl="34" data1="255" data2="28" data3="4" scene="1" syncstatus="changed" uid="52662627" />
+          </record>
+          <record sequence="40">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="1470404457" />
+          </record>
+          <record sequence="41">
+            <device address="55.55.55" group="6" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3243379164" />
+          </record>
+          <record sequence="42">
+            <device address="11.11.11" group="3" recordControl="162" data1="255" data2="28" data3="4" scene="1" syncstatus="synced" uid="3897768486" />
+          </record>
+          <record sequence="43">
+            <device address="11.11.11" group="3" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3396315979" />
+          </record>
+          <record sequence="44">
+            <device address="11.11.11" group="3" recordControl="34" data1="76" data2="28" data3="5" scene="1" syncstatus="changed" uid="3292049869" />
+          </record>
+          <record sequence="45">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="1158730727" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="55.55.55" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Ceiling Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/20/2024 10:38:09 AM" lastStatus="Changed" revision="0" nextRecordToRead="0">
+          <record sequence="0">
+            <device address="11.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2608138669" />
+          </record>
+          <record sequence="1">
+            <device address="22.22.22" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2030677227" />
+          </record>
+          <record sequence="2">
+            <device address="33.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="3343325901" />
+          </record>
+          <record sequence="3">
+            <device address="44.44.44" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2004449499" />
+          </record>
+          <record sequence="4">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="3338808532" />
+          </record>
+          <record sequence="5">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1320770182" />
+          </record>
+          <record sequence="6">
+            <device address="11.11.11" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="832536136" />
+          </record>
+          <record sequence="7">
+            <device address="22.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2401478932" />
+          </record>
+          <record sequence="8">
+            <device address="33.33.33" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1429469508" />
+          </record>
+          <record sequence="9">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="886819718" />
+          </record>
+          <record sequence="10">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="701261943" />
+          </record>
+          <record sequence="11">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="712185641" />
+          </record>
+          <record sequence="12">
+            <device address="11.11.11" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="995507586" />
+          </record>
+          <record sequence="13">
+            <device address="22.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="3551681136" />
+          </record>
+          <record sequence="14">
+            <device address="33.33.33" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1355429460" />
+          </record>
+          <record sequence="15">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="4087067396" />
+          </record>
+          <record sequence="16">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="304313340" />
+          </record>
+          <record sequence="17">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1023858529" />
+          </record>
+          <record sequence="18">
+            <device address="11.11.11" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="937610989" />
+          </record>
+          <record sequence="19">
+            <device address="22.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="879644607" />
+          </record>
+          <record sequence="20">
+            <device address="33.33.33" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2352412577" />
+          </record>
+          <record sequence="21">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="766266831" />
+          </record>
+          <record sequence="22">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1672097903" />
+          </record>
+          <record sequence="23">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1650539561" />
+          </record>
+          <record sequence="24">
+            <device address="11.11.11" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="4009249125" />
+          </record>
+          <record sequence="25">
+            <device address="22.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="960171428" />
+          </record>
+          <record sequence="26">
+            <device address="33.33.33" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1903515650" />
+          </record>
+          <record sequence="27">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1550206752" />
+          </record>
+          <record sequence="28">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2539369256" />
+          </record>
+          <record sequence="29">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1045050751" />
+          </record>
+          <record sequence="30">
+            <device address="11.11.11" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1547481841" />
+          </record>
+          <record sequence="31">
+            <device address="22.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2591953303" />
+          </record>
+          <record sequence="32">
+            <device address="33.33.33" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="887423870" />
+          </record>
+          <record sequence="33">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="80938527" />
+          </record>
+          <record sequence="34">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="761631269" />
+          </record>
+          <record sequence="35">
+            <device address="44.44.44" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="2736953566" />
+          </record>
+          <record sequence="36">
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="604795073" />
+          </record>
+        </database>
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="AA.AA.AA" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Under Cabinet Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="BB.BB.BB" category="1" subcategory="66" revision="67" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="KeypadLinc03DCS" displayName="Keypad - Nook Ceiling Lights" active="1">
+        <location />
+        <channels>
+          <channel id="1" lastStatus="Synchronized" />
+          <channel id="2" lastStatus="Synchronized" />
+          <channel id="3" lastStatus="Synchronized" />
+          <channel id="4" lastStatus="Synchronized" />
+          <channel id="5" lastStatus="Synchronized" />
+          <channel id="6" lastStatus="Synchronized" />
+        </channels>
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+      <device insteonID="CC.CC.CC" category="1" subcategory="32" revision="65" powerline="1" radio="1" yakityYak="1" hopIfModSyncFails="1" ipk="00.00.00" wattage="30" webDeviceID="0" webGatewayControllerGroup="0" driver="SwitchLinc02DCS" displayName="Pantry Lights" active="1">
+        <location />
+        <channels />
+        <database sequence="0" lastUpdate="12/19/2024 10:14:55 AM" lastStatus="Synchronized" revision="0" nextRecordToRead="0" />
+        <properties lastStatus="Synchronized" />
+      </device>
+    </active_devices>
+    <scenes nextSceneID="2">
+      <scene id="1" name="Kitchen" lastTrigger="05/17/2014 11:02:08 AM, On" notes="Turn on kitchen main lights">
+        <members>
+          <member iid="11.11.11" group="2" controller="1" responder="1" data1="255" data2="28" data3="2" status="Done" tag="35" />
+          <member iid="22.22.22" group="1" controller="1" responder="1" data1="76" data2="28" data3="1" status="Done" tag="1" />
+          <member iid="33.33.33" group="1" responder="1" data1="153" data2="28" data3="1" status="Done" tag="1" />
+          <member iid="44.44.44" group="4" responder="1" data1="255" data2="28" data3="4" status="Done" tag="35" />
+          <member iid="55.55.55" group="6" controller="1" data1="255" data2="28" data3="6" status="Done" tag="35" />
+          <member iid="44.44.44" group="5" responder="1" data1="76" data2="28" data3="5" status="Done" tag="33" />
+          <member iid="11.11.11" group="3" controller="1" data1="160" data2="28" data3="3" status="Done" tag="35" />
+        </members>
+      </scene>
+    </scenes>
+  </insteon>
+</settings>

--- a/UnitTestApp/UnitTestApp.csproj
+++ b/UnitTestApp/UnitTestApp.csproj
@@ -10,10 +10,6 @@
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>
-  <ItemGroup>
-    <None Remove="Models\Changes\Changes2.xml" />
-    <None Remove="Refs\Changes\TestChangeChannels.xml" />
-  </ItemGroup>
   
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
@@ -29,6 +25,8 @@
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+    <Content Include="Models\Scenes\Scene2.xml" />
+    <Content Include="Models\Scenes\Scene2Expanded.xml" />
     <Content Include="Refs\Changes\TestAddDevice.xml" />
     <Content Include="Refs\Changes\TestAddDeviceWithChannels.xml" />
     <Content Include="Refs\Changes\TestAddDuplicateRecordToDatabase.xml" />
@@ -44,6 +42,9 @@
     <Content Include="Refs\Changes\TestReplaceDevice.xml" />
     <Content Include="Refs\Changes\TestReplaceDeviceWithChannels.xml" />
     <Content Include="Refs\Merges\TestAddDeviceLocalAndOther.xml" />
+    <Content Include="Refs\Scenes2\TestExpandScene.xml" />
+    <Content Include="Refs\Scenes2\TestRemoveDuplicateMembers.xml" />
+    <Content Include="Refs\Scenes2\TestRemoveDuplicateMembersOneByOne.xml" />
     <Content Include="Refs\Scenes\TestAddController.xml" />
     <Content Include="Refs\Scenes\TestAddResponder.xml" />
     <Content Include="Refs\Scenes\TestEditControllerData.xml" />


### PR DESCRIPTION
This change fixes several issues in the handling of duplicate members and generated links when removing a duplicated member from a scene. The general approach is to match the links to remove with existing links in each device database and remove all links but one.

Though it is rare to create duplicate links as the algorithm expanding a scene to links should ensure that no duplicate is produced, this can happen during manual creating of links, when merging the changes from two instances of the app running concurrently, and possibly in other edge situations. We want to be robust in the face of that eventuality.
 
Added unit tests working off a house config file with duplicated scene members and heavy duplication of links to test cleaning up duplicate members/links when removing one or more scene members.