### PR TITLE
Fixed issue in LevelControl

### DIFF
--- a/HouzLinc/Controls/LevelControl.xaml.cs
+++ b/HouzLinc/Controls/LevelControl.xaml.cs
@@ -117,7 +117,7 @@ public sealed partial class LevelControl : UserControl, INotifyPropertyChanged
     // TODO: make private when https://github.com/unoplatform/uno/pull/14521 is fixed
     public string stringPercentLevel
     {
-        get => $"{doublePercentLevel:F0}%";
+        get => _stringPercentLevel;
         set
         {
             if (value != _stringPercentLevel)


### PR DESCRIPTION
This change restores the ability to change the level in LevelControl by typing in the textbox.