### PR TITLE
Fixed obvious bug in OnLevel property of DeviceViewModel

### DIFF
--- a/ViewModel/Devices/DeviceViewModel.cs
+++ b/ViewModel/Devices/DeviceViewModel.cs
@@ -556,7 +556,7 @@ public class DeviceViewModel : LinkHostViewModel, IDeviceObserver, IRoomsObserve
         {
             // See above
             Debug.Assert(nameof(OnLevel) == nameof(Device.OnLevel));
-            Device.LEDBrightness = (byte)value;
+            Device.OnLevel = (byte)value;
         }
     }
 


### PR DESCRIPTION
Due to a type in a previous change, the OnLevel property of DeviceViewModel would set LEDBrightness instead.