### PR TITLE
Allow to add Insteon v1 devices

### DIFF
--- a/Insteon/Commands/EnterLinkingModeCommand.cs
+++ b/Insteon/Commands/EnterLinkingModeCommand.cs
@@ -30,7 +30,19 @@ public sealed class EnterLinkingModeCommand : DeviceCommand
         ToDeviceID = deviceId;
         Command1 = CommandCode_EnterLinkingMode;
         Command2 = group;
-        ClearData();
+    }
+
+    private protected override async Task<bool> RunAsync()
+    {
+        // Determine the version of the Insteon engine on the device
+        var command = new GetInsteonEngineVersionCommand(gateway, ToDeviceID);
+        if (await command.TryRunAsync(parentCommand: Running) && command.EngineVersion >= 2)
+        {
+            // If version 2 or above, send extended command
+            ClearData();
+        }
+
+        return await base.RunAsync();
     }
 
     /// <summary>


### PR DESCRIPTION
This change makes it possible to add an Insteon v1 device by using the standard (not extended) version of Enter Linking Mode command. Not that some commands won't work with Insteon v1 devices (including Get Link Record), so more work is necessary to fully handle these devices.