### PR TITLE
Acquire, persist and show Engine Version

### DIFF
--- a/HouzLinc/Views/Devices/DeviceInformationView.xaml
+++ b/HouzLinc/Views/Devices/DeviceInformationView.xaml
@@ -44,6 +44,13 @@
                     <TextBlock Text="{x:Bind Revision}"/>
                 </ctkControls:SettingsCard>
 
+                <ctkControls:SettingsCard Header="Engine Version" MinHeight="48">
+                    <ctkControls:SettingsCard.Resources>
+                        <x:Double x:Key="SettingsCardWrapThreshold">350</x:Double>
+                    </ctkControls:SettingsCard.Resources>
+                    <TextBlock Text="{x:Bind EngineVersion, Mode=OneWay}"/>
+                </ctkControls:SettingsCard>
+
               <!--
               <ctkControls:SettingsCard Header="RF Enabled" >
                     <ctkControls:SettingsCard.Resources>

--- a/Insteon/Drivers/DeviceDriver.cs
+++ b/Insteon/Drivers/DeviceDriver.cs
@@ -102,20 +102,6 @@ internal class DeviceDriver : DeviceDriverBase
     }
 
     /// <summary>
-    /// Check that the Insteon Engine version is at least 2
-    /// </summary>
-    /// <returns>whether it is</returns>
-    internal async override Task<bool> TryCheckInsteonEngineVersionAsync()
-    {
-        var command = new GetInsteonEngineVersionCommand(House.Gateway, Id);
-        if (await command.TryRunAsync())
-        {
-            return (command.EngineVersion >= 2);
-        }
-        return false;
-    }
-
-    /// <summary>
     /// Turn light device on at specified level
     /// </summary>
     /// <param name="level"></param>

--- a/Insteon/Drivers/DeviceDriverBase.cs
+++ b/Insteon/Drivers/DeviceDriverBase.cs
@@ -95,12 +95,6 @@ public abstract class DeviceDriverBase : DeviceBase
     internal abstract Task<double> TryGetLightOnLevel();
 
     /// <summary>
-    /// Read Insteon engine version (v1 or v2)
-    /// </summary>
-    /// <returns>success</returns>
-    internal abstract Task<bool> TryCheckInsteonEngineVersionAsync();
-
-    /// <summary>
     /// Whether the physical device has operating flags
     /// </summary>
     internal virtual bool HasOperatingFlags => true;

--- a/Insteon/Drivers/IMDriver.cs
+++ b/Insteon/Drivers/IMDriver.cs
@@ -90,18 +90,6 @@ internal sealed class IMDriver : DeviceDriverBase
     }
 
     /// <summary>
-    /// Check Insteon Engine version
-    /// Always 2 for the IM
-    /// </summary>
-    /// <returns>always true</returns>
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-    internal override async Task<bool> TryCheckInsteonEngineVersionAsync()
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
-    {
-        return true;
-    }
-
-    /// <summary>
     /// Turn light device on at specified level - not implemented for the IM
     /// </summary>
     /// <param name="level"></param>

--- a/Insteon/Model/Devices.cs
+++ b/Insteon/Model/Devices.cs
@@ -866,27 +866,32 @@ public sealed class Devices : OrderedKeyedList<Device>
                     deviceWithIsNew.IsNew = true;
                 }
 
-                // Set properties given by the IMAllLinking command
-                // after adding the device to this Devices list to generate proper change deltas
+                // Set product data given by the IMAllLinking command
+                // (after adding the device to this Devices list to generate proper change deltas)
                 device.CategoryId = cmd.DeviceCategory;
                 device.SubCategory = cmd.DeviceSubCategory;
-                device.Revision = cmd.DeviceFirmwareRevision;
-                device.Status = Device.ConnectionStatus.Connected;
 
-                // Read the properties of the new device
-                // This is relatively cheap so do immediately to update the UI
-                device.ResetPropertiesSyncStatus();
-                await device.TryReadDevicePropertiesAsync(forceSync: true);
+                // Get the rest of the product data
+                // If we fail to acquire product data, we'll run with the information obtained
+                // from the IMAllLinking command, and try again later as part of device synchronization.
+                if (await device.TryReadProductDataAsync())
+                {
+                    // Read the properties of the new device
+                    // This is relatively cheap so do immediately to update the UI
+                    device.ResetPropertiesSyncStatus();
+                    await device.TryReadDevicePropertiesAsync(forceSync: true);
 
-                // Mark link database of the device unknown to force reading from physical device
-                device.AllLinkDatabase.ResetSyncStatus();
+                    // Mark link database of the device unknown to force reading from physical device
+                    device.AllLinkDatabase.ResetSyncStatus();
 
-                // Mark hub database unknown to force reading from physical device
-                // and acquire link just added for the new device
-                var hub = GetDeviceByID(House.Gateway.DeviceId);
-                hub?.AllLinkDatabase.ResetSyncStatus();
+                    // Mark hub database unknown to force reading from physical device
+                    // and acquire link just added for the new device
+                    var hub = GetDeviceByID(House.Gateway.DeviceId);
+                    hub?.AllLinkDatabase.ResetSyncStatus();
 
-                deviceWithIsNew.Device = device;
+                    deviceWithIsNew.Device = device;
+                }
+
                 return deviceWithIsNew;
             }
         }
@@ -938,27 +943,32 @@ public sealed class Devices : OrderedKeyedList<Device>
                     deviceWithIsNew.IsNew = true;
                 }
 
-                // Set properties given by the IMAllLinking command
-                // after adding the device to this Devices list to generate proper change deltas
+                // Set product data given by the IMAllLinking command
+                // (after adding the device to this Devices list to generate proper change deltas)
                 device.CategoryId = cmd.DeviceCategory;
                 device.SubCategory = cmd.DeviceSubCategory;
-                device.Revision = cmd.DeviceFirmwareRevision;
-                device.Status = Device.ConnectionStatus.Connected;
 
-                // Read the other properties of the new device
-                // This is relatively cheap so do immediately to update the UI
-                device.ResetPropertiesSyncStatus();
-                await device.TryReadDevicePropertiesAsync(forceSync: true);
+                // Get the rest of the product data
+                // If we fail to acquire product data, we'll run with the information obtained
+                // from the IMAllLinking command, and try again later as part of device synchronization.
+                if (await device.TryReadProductDataAsync())
+                {
+                    // Read the other properties of the new device
+                    // This is relatively cheap so do immediately to update the UI
+                    device.ResetPropertiesSyncStatus();
+                    await device.TryReadDevicePropertiesAsync(forceSync: true);
 
-                // Mark link database of the device unknown to force reading from physical device
-                device.AllLinkDatabase.ResetSyncStatus();
+                    // Mark link database of the device unknown to force reading from physical device
+                    device.AllLinkDatabase.ResetSyncStatus();
 
-                // Mark hub database unknown to force reading from physical network via background sync
-                // and acquire link just added for the new device
-                var hub = GetDeviceByID(House.Gateway.DeviceId);
-                hub?.AllLinkDatabase.ResetSyncStatus();
+                    // Mark hub database unknown to force reading from physical network via background sync
+                    // and acquire link just added for the new device
+                    var hub = GetDeviceByID(House.Gateway.DeviceId);
+                    hub?.AllLinkDatabase.ResetSyncStatus();
 
-                deviceWithIsNew.Device = device;
+                    deviceWithIsNew.Device = device;
+                }
+
                 return deviceWithIsNew;
             }
         }

--- a/Insteon/Serialization/Houselinc/HLDevice.cs
+++ b/Insteon/Serialization/Houselinc/HLDevice.cs
@@ -37,6 +37,7 @@ public sealed class HLDevice
         CategoryId = device.CategoryId;
         SubCategory = device.SubCategory;
         Revision = device.Revision;
+        EngineVersion = device.EngineVersion;
         Status = device.Status;
         Powerline = device.Powerline;
         Radio = device.Radio;
@@ -67,6 +68,7 @@ public sealed class HLDevice
             CategoryId = CategoryId,
             SubCategory = SubCategory,
             Revision = Revision,
+            EngineVersion = EngineVersion,
             Status = Status,
             Powerline = Powerline,
             Radio = Radio,
@@ -129,6 +131,11 @@ public sealed class HLDevice
     public int RevisionSerialized { get => Revision; set => Revision = value; }
     [XmlIgnore]
     public int Revision { get; set; }
+
+    [XmlAttribute("engineVersion")]
+    public int EngineVersionSerialized { get => EngineVersion; set => EngineVersion = value; }
+    [XmlIgnore]
+    public int EngineVersion { get; set; }
 
     /// <summary>
     /// Device status

--- a/ViewModel/Devices/DeviceViewModel.cs
+++ b/ViewModel/Devices/DeviceViewModel.cs
@@ -410,6 +410,12 @@ public class DeviceViewModel : LinkHostViewModel, IDeviceObserver, IRoomsObserve
     /// </summary>
     public string Revision => this.Device.Revision.ToString();
 
+    /// <summary>
+    /// Engine version (1-3)
+    /// Read only (one-time bindable), obtained from the physical device during linking
+    /// </summary>
+    public string EngineVersion => this.Device.EngineVersion.ToString();
+
     //---------------------------------------------------------------------------
     // Read/write, 2-way bindable properties synced with the physical device
     //---------------------------------------------------------------------------


### PR DESCRIPTION
With this change we acquire Insteon Engine version as part of product data, persist it a part of House Config, and show it in the UI in preparation for supporting version 1 (maybe) and 3. 
