### PR TITLE
Fixed assert when discovering the hub

### DIFF
--- a/Insteon/Model/Devices.cs
+++ b/Insteon/Model/Devices.cs
@@ -181,6 +181,7 @@ public sealed class Devices : OrderedKeyedList<Device>
                 device.CategoryId = cmd.CategoryId;
                 device.SubCategory = cmd.Subcategory;
                 device.Revision = cmd.FirmwareRevision;
+                device.IsProductDataRead = true;
             }
 
             device.EnsureChannels();


### PR DESCRIPTION
`Device.IsProductDataRead` was not set when the hub was discovered, leading at to a failed assert when attempting to create the IM driver. Fixed it.