### PR TITLE
Improvements to first-time experience

### DIFF
--- a/HouzLinc/Views/Console/ConsolePage.xaml
+++ b/HouzLinc/Views/Console/ConsolePage.xaml
@@ -27,12 +27,14 @@
 
         <TextBlock Text="{x:Bind PageHeaderProperty}" VerticalAlignment="Top" Style="{StaticResource TitleTextBlockStyle}"/>
 
+        <!--
         <TextBlock
             HorizontalAlignment="Right"
             Margin="5,15,5,15"
             TextWrapping="NoWrap"
             Style="{StaticResource CaptionTextBlockStyle}"
             Text="{x:Bind sys:String.Format(x:Null, 'Hub: https//:{0}:{1} - {2}', SettingsViewModel.HubIPAddress, SettingsViewModel.HubIPPort, SettingsViewModel.HubInsteonID), Mode=OneWay}"/>
+        -->
 
         <ScrollViewer
             Grid.Row="1"

--- a/HouzLinc/Views/Settings/HubSettingsPage.xaml
+++ b/HouzLinc/Views/Settings/HubSettingsPage.xaml
@@ -28,19 +28,24 @@
 
         <TextBlock Text="{x:Bind PageHeaderProperty}" VerticalAlignment="Top" Style="{StaticResource TitleTextBlockStyle}"/>
 
+        <!--
         <TextBlock
             HorizontalAlignment="Right"
             Margin="5,15,5,15"
             TextWrapping="NoWrap"
             Style="{StaticResource CaptionTextBlockStyle}"
             Text="{x:Bind sys:String.Format(x:Null, 'Hub: https//:{0}:{1} - {2}', SettingsViewModel.HubIPAddress, SettingsViewModel.HubIPPort, SettingsViewModel.HubInsteonID), Mode=OneWay}"/>
+        -->
 
         <ScrollViewer Grid.Row="1" Margin="0,10,0,10">
             <StackPanel Margin="10,0,20,0">
                 <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="HouzLinc needs some information about your Insteon Hub to access your Insteon network."/>
-                <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="Please enter the MAC address, port, username and password of your Insteon Hub below. You will find that information on the back of your Insteon Hub. Then click 'Find Hub'."/>
-                <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="If the hub is not found, look up its IP address on your local network. You can usually find that information in your router portal. Enter the IP address and click 'Find Hub' again."/>
+                <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="Please enter the information marked * below and click 'Find&#160;Hub'. You will find that information on the back of your Insteon Hub."/>
+                <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="If the hub is not found, look up its IP address on your local network. You can usually find that information in your router app/portal. Enter the IP address and click 'Find&#160;Hub' again."/>
                 <local:HubSettingsView Margin="0,15,0,0" Content="{x:Bind SettingsViewModel}"/>
+                <TextBlock Margin="0,15,0,0" Visibility="{x:Bind SettingsViewModel.IsHubFound, Mode=OneWay}">
+                    Click<Span xml:space="preserve"> <Hyperlink Click="NavigateToDevices">here</Hyperlink></Span>
+                    or select the 'Devices' tab to start adding or discovering devices.</TextBlock>
             </StackPanel>
         </ScrollViewer>
 

--- a/HouzLinc/Views/Settings/HubSettingsPage.xaml.cs
+++ b/HouzLinc/Views/Settings/HubSettingsPage.xaml.cs
@@ -16,6 +16,8 @@
 using HouzLinc.Views.Base;
 using ViewModel.Settings;
 using ViewModel.Base;
+using Microsoft.UI.Xaml.Media.Animation;
+using HouzLinc.Views.Devices;
 
 namespace HouzLinc.Views.Settings;
 
@@ -36,4 +38,9 @@ public sealed partial class HubSettingsPage : PageWithViewModels
     // View Models
     private SettingsViewModel SettingsViewModel => SettingsViewModel.Instance;
     private StatusBarViewModel StatusBarViewModel => StatusBarViewModel.Instance;
+
+    private void NavigateToDevices(object sender, RoutedEventArgs e)
+    {
+        (App.MainWindow.Content as AppShell)?.Navigate(typeof(DeviceListPage), null, new DrillInNavigationTransitionInfo());
+    }
 }

--- a/HouzLinc/Views/Settings/HubSettingsView.xaml
+++ b/HouzLinc/Views/Settings/HubSettingsView.xaml
@@ -24,7 +24,7 @@
                     See: https://github.com/unoplatform/uno/issues/18219
                 -->
 
-                <ctkControls:SettingsCard Description="" Header="Hub MAC Address">
+                <ctkControls:SettingsCard Description="" Header="Hub MAC Address *">
                     <ctkControls:SettingsCard.Resources>
                         <x:Double x:Key="SettingsCardWrapThreshold">300</x:Double>
                         <x:Double x:Key="SettingsCardWrapNoIconThreshold">200</x:Double>
@@ -45,7 +45,7 @@
                         Text="{x:Bind HubMacAddress, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"/>
                 </ctkControls:SettingsCard>
 
-                <ctkControls:SettingsCard Description="" Header="Hub IP Port">
+                <ctkControls:SettingsCard Description="" Header="Hub IP Port *">
                     <ctkControls:SettingsCard.Resources>
                         <x:Double x:Key="SettingsCardWrapThreshold">300</x:Double>
                         <x:Double x:Key="SettingsCardWrapNoIconThreshold">200</x:Double>
@@ -58,7 +58,7 @@
                         TextWrapping="NoWrap"/>
                 </ctkControls:SettingsCard>
 
-                <ctkControls:SettingsCard Description="" Header="Hub Username">
+                <ctkControls:SettingsCard Description="" Header="Hub Username *">
                     <ctkControls:SettingsCard.Resources>
                         <x:Double x:Key="SettingsCardWrapThreshold">300</x:Double>
                         <x:Double x:Key="SettingsCardWrapNoIconThreshold">200</x:Double>
@@ -71,7 +71,7 @@
                         TextWrapping="NoWrap"/>
                 </ctkControls:SettingsCard>
 
-                <ctkControls:SettingsCard Description="" Header="Hub Password">
+                <ctkControls:SettingsCard Description="" Header="Hub Password *">
                     <ctkControls:SettingsCard.Resources>
                         <x:Double x:Key="SettingsCardWrapThreshold">300</x:Double>
                         <x:Double x:Key="SettingsCardWrapNoIconThreshold">200</x:Double>

--- a/HouzLinc/Views/Settings/SettingsPage.xaml
+++ b/HouzLinc/Views/Settings/SettingsPage.xaml
@@ -30,12 +30,14 @@
 
         <TextBlock Text="{x:Bind PageHeaderProperty}" VerticalAlignment="Top" Style="{StaticResource TitleTextBlockStyle}"/>
 
+        <!--
         <TextBlock
             HorizontalAlignment="Right"
             Margin="5,15,5,15"
             TextWrapping="NoWrap"
             Style="{StaticResource CaptionTextBlockStyle}"
             Text="{x:Bind sys:String.Format(x:Null, 'Hub: https//:{0}:{1} - {2}', SettingsViewModel.HubIPAddress, SettingsViewModel.HubIPPort, SettingsViewModel.HubInsteonID), Mode=OneWay}"/>
+        -->
 
         <ScrollViewer Grid.Row="1" Margin="0,10,0,10">
             <StackPanel Margin="10,0,20,0">
@@ -43,12 +45,12 @@
                     Margin="0,10,0,0"
                     TextWrapping="Wrap"
                     Visibility="{x:Bind SettingsViewModel.IsHubFound, Converter={StaticResource VisibilityNegation}, Mode=OneWay}"
-                    Text="Enter your Insteon Hub MAC, port, username and password below and click 'Find Hub'. You will find that information on the back of your Insteon Hub."/>
+                    Text="Please enter the information marked * below and click 'Find&#160;Hub'. You will find that information on the back of your Insteon Hub."/>
                 <TextBlock
                     Margin="0,10,0,0"
                     TextWrapping="Wrap"
                     Visibility="{x:Bind SettingsViewModel.IsHubFound, Converter={StaticResource VisibilityNegation}, Mode=OneWay}"
-                    Text="If the hub is not found, look up its IP address on your local network. You can usually find that information in your router portal. Enter the IP address and click 'Find Hub'."/>
+                    Text="If the hub is not found, look up its IP address on your local network. You can usually find that information in your router app/portal. Enter the IP address and click 'Find&#160;Hub' again."/>
 
                 <local:HubSettingsView Margin="0,15,0,15" Content="{x:Bind SettingsViewModel}"/>
 

--- a/HouzLinc/Views/Tools/ToolsPage.xaml
+++ b/HouzLinc/Views/Tools/ToolsPage.xaml
@@ -28,12 +28,14 @@
 
         <TextBlock Text="{x:Bind PageHeaderProperty}" VerticalAlignment="Top" Style="{StaticResource TitleTextBlockStyle}"/>
 
+        <!--
         <TextBlock
             HorizontalAlignment="Right"
             Margin="5,15,5,15"
             TextWrapping="NoWrap"
             Style="{StaticResource CaptionTextBlockStyle}"
             Text="{x:Bind sys:String.Format(x:Null, 'Hub: https//:{0}:{1} - {2}', SettingsViewModel.HubIPAddress, SettingsViewModel.HubIPPort, SettingsViewModel.HubInsteonID), Mode=OneWay}"/>
+        -->
 
         <StackPanel Grid.Row="1" Margin="5,0,0,0">
             <StackPanel Orientation="Vertical" Margin="-12,0,0,0">


### PR DESCRIPTION
Improved prompt to enter hub information.
Added mention and link to go to Devices page to start adding devices after discovering the hub. 
Tentatively removed mention of hub IP address and InsteonID at the top of SettingsPage, ConsolePage, ToolsPage to lighten up UI.