### PR TITLE
Added UI when we have no Hub, Device or Scene.

### DIFF
--- a/HouzLinc/Dialogs/NewDeviceDialog.xaml
+++ b/HouzLinc/Dialogs/NewDeviceDialog.xaml
@@ -24,14 +24,14 @@
             <TextBlock Text="No device with the id that you entered was found on your network. Try another device id, or try to auto-discover the device." TextWrapping="Wrap"/>
         </Border>
 
-        <TextBlock Margin="0,10,0,10" Text="Either enter the device id below and click 'Add'." TextWrapping="Wrap"/>
+        <TextBlock Margin="0,10,0,10" Text="Either enter the device id below and tap 'Add'." TextWrapping="Wrap"/>
         <ctl:DeviceIDBox
             x:Name="DeviceIdBox"
             HorizontalAlignment="Center"
             Margin="0,0,0,0"
             IsEnabled="{x:Bind isAutoDiscovering, Converter={StaticResource BoolNegation}, Mode=OneWay}"/>
 
-        <TextBlock Margin="0,20,0,0" Text="Or auto-discover the device: click below, then walk to the device and press and hold its 'set' button." TextWrapping="Wrap"/>
+        <TextBlock Margin="0,20,0,0" Text="Or auto-discover the device: tap below, then walk to the device and press and hold its 'set' button." TextWrapping="Wrap"/>
         <Button
             Content="Auto-discover device"
             Margin="0,20,0,0"

--- a/HouzLinc/Views/Devices/DeviceListPage.xaml
+++ b/HouzLinc/Views/Devices/DeviceListPage.xaml
@@ -106,9 +106,40 @@
                 SelectedItem="{x:Bind deviceListViewModel.SortOrder, Mode=TwoWay}"/>
         </StackPanel>
 
+        <!-- No device to show -->
+        <StackPanel
+            x:Name="EmptyListView"
+            x:Load="{x:Bind deviceListViewModel.IsEmpty, Mode=OneWay}"
+            Grid.Row="2"
+            Margin="10,15,10,0">
+            <StackPanel x:Name="HubNotFound" x:Load="{x:Bind settingsViewModel.IsHubNotFound}">
+                <TextBlock TextWrapping="Wrap" Text="The hub was not found on your local network!"/>
+                <TextBlock Margin="0,15,0,0">
+                    <Span xml:space="preserve">Please <Hyperlink Click="NavigateToHubSettings">review the hub information</Hyperlink></Span>
+                    .</TextBlock>
+            </StackPanel>
+            <StackPanel x:Name="HubFound" x:Load="{x:Bind settingsViewModel.IsHubFound}">
+                <TextBlock TextWrapping="Wrap" Text="There is no device to show here yet! "/>
+                <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="You can add a device by tapping:"/>
+                <Button
+                    Tag="AddDevice"
+                    win:ToolTipService.ToolTip="Add Device"
+                    Margin="0,4,0,0"
+                    Style="{ThemeResource SplitViewPaneButtonStyle}"
+                    Click="AddDeviceBtnClick">
+                    <SymbolIcon Symbol="Add"/>
+                </Button>
+                <TextBlock TextWrapping="Wrap">either here or at top right of this page.</TextBlock>
+                <TextBlock Margin="0,10,0,0" TextWrapping="Wrap">
+                    If you aleady have devices in your Insteon<Span xml:space="preserve"> network, <Hyperlink Click="{x:Bind toolsViewModel.ScheduleImportAllDevices}">try discovering them.</Hyperlink></Span>
+                </TextBlock>
+            </StackPanel>
+        </StackPanel>
+
         <!-- Device List -->
         <ListView
             x:Name="DeviceListView"
+            Visibility="{x:Bind deviceListViewModel.IsEmpty, Converter={StaticResource VisibilityNegation}, Mode=OneWay}"
             Grid.Row="2"
             Margin="5,0,5,2"
             EntranceNavigationTransitionInfo.IsTargetElement="True"

--- a/HouzLinc/Views/Devices/DeviceListPage.xaml.cs
+++ b/HouzLinc/Views/Devices/DeviceListPage.xaml.cs
@@ -13,13 +13,14 @@
    limitations under the License.
 */
 
-using System.Collections.ObjectModel;
 using HouzLinc.Views.Base;
 using HouzLinc.Dialogs;
 using Common;
 using ViewModel.Devices;
 using ViewModel.Settings;
-using ViewModel.Base;
+using ViewModel.Tools;
+using Microsoft.UI.Xaml.Media.Animation;
+using HouzLinc.Views.Settings;
 
 namespace HouzLinc.Views.Devices;
 
@@ -89,6 +90,10 @@ public sealed partial class DeviceListPage : DeviceListPageBase
             .ApplyFilterAndSortOrderFromSettings();
     private DeviceListViewModel? itemsListViewModel;
     private DeviceListViewModel deviceListViewModel => (ItemListViewModel as DeviceListViewModel)!;
+
+    // Additional view models referenced on this page
+    private SettingsViewModel settingsViewModel => SettingsViewModel.Instance;
+    private ToolsViewModel toolsViewModel => ToolsViewModel.Instance;
 
     // Control accessors for base page
     protected override ListView ItemListView => DeviceListView;
@@ -160,5 +165,10 @@ public sealed partial class DeviceListPage : DeviceListPageBase
                 
             }
         }
+    }
+
+    private void NavigateToHubSettings(Microsoft.UI.Xaml.Documents.Hyperlink sender, Microsoft.UI.Xaml.Documents.HyperlinkClickEventArgs args)
+    {
+        (App.MainWindow.Content as AppShell)?.Navigate(typeof(HubSettingsPage), null, new DrillInNavigationTransitionInfo());
     }
 }

--- a/HouzLinc/Views/Devices/KeypadButtonPropertyHeaderView.xaml
+++ b/HouzLinc/Views/Devices/KeypadButtonPropertyHeaderView.xaml
@@ -22,7 +22,7 @@
         <DataTemplate x:DataType="vm:KeypadLincViewModel">
             <StackPanel>
                 <TextBlock Text="Button Properties" Style="{StaticResource SubtitleTextBlockStyle}"/>
-                <TextBlock Margin="0,5,0,0"  Text="Click a button to view and edit its properties."/>
+                <TextBlock Margin="0,5,0,0"  Text="Select a button to view and edit its properties."/>
                 <TextBlock Margin="0,5,0,0"  Text="Shift click another to make it follow on, follow off or not follow."/>
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Margin="0,5,0,0" Text="Or pin a button "/>
@@ -33,7 +33,7 @@
                         win:ToolTipService.ToolTip="Pin Selected Button to Configure Followers">
                         <SymbolIcon Symbol="Pin"/>
                     </ToggleButton>
-                    <TextBlock Margin="5,5,0,0" Text="and click another to make it follow on, follow off or not follow."/>
+                    <TextBlock Margin="5,5,0,0" Text="and tap another to make it follow on, follow off or not follow."/>
                 </StackPanel>
             </StackPanel>
         </DataTemplate>

--- a/HouzLinc/Views/Hub/HubChannelListPage.xaml
+++ b/HouzLinc/Views/Hub/HubChannelListPage.xaml
@@ -79,9 +79,22 @@
                 SelectedItem="{x:Bind hubChannelListViewModel.SortOrder, Mode=TwoWay}"/>
         </StackPanel>
 
+        <!-- Hub is not discovered -->
+        <StackPanel
+            x:Name="EmptyListView"
+            x:Load="{x:Bind settingsViewModel.IsHubNotFound, Mode=OneWay}"
+            Grid.Row="2"
+            Margin="10,15,10,0">
+            <TextBlock TextWrapping="Wrap" Text="The hub was not found on your local network!"/>
+            <TextBlock Margin="0,15,0,0">
+                <Span xml:space="preserve">Please <Hyperlink Click="NavigateToHubSettings">review the hub information</Hyperlink></Span>
+                .</TextBlock>
+        </StackPanel>
+
         <!-- List of Channels -->
         <ListView
             x:Name="ChannelListView"
+            Visibility="{x:Bind settingsViewModel.IsHubFound, Mode=OneWay}"
             Grid.Row="2"
             Margin="5,0,5,2"
             EntranceNavigationTransitionInfo.IsTargetElement="True"

--- a/HouzLinc/Views/Hub/HubChannelListPage.xaml.cs
+++ b/HouzLinc/Views/Hub/HubChannelListPage.xaml.cs
@@ -13,11 +13,11 @@
    limitations under the License.
 */
 
-using System.Collections.ObjectModel;
 using HouzLinc.Views.Base;
 using ViewModel.Hub;
-using ViewModel.Base;
 using ViewModel.Settings;
+using Microsoft.UI.Xaml.Media.Animation;
+using HouzLinc.Views.Settings;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -49,10 +49,17 @@ public sealed partial class HubChannelListPage : HubChannelListPageBase
     protected override HubChannelListViewModel ItemListViewModel => itemsListViewModel ??= HubChannelListViewModel.Create();
     private HubChannelListViewModel? itemsListViewModel;
     private HubChannelListViewModel hubChannelListViewModel => (ItemListViewModel as HubChannelListViewModel)!;
+    private SettingsViewModel settingsViewModel => SettingsViewModel.Instance;
 
     // Control accessors for base page
     protected override ListView ItemListView => ChannelListView;
     protected override ContentControl ItemDetailsPresenter => HubChannelDetailsPresenter;
     protected override VisualStateGroup PageSizeVisualStateGroup => PageSizeStatesGroup;
     protected override VisualStateGroup MasterDetailVisualStateGroup => MasterDetailsStatesGroup;
+
+    private void NavigateToHubSettings(Microsoft.UI.Xaml.Documents.Hyperlink sender, Microsoft.UI.Xaml.Documents.HyperlinkClickEventArgs args)
+    {
+        (App.MainWindow.Content as AppShell)?.Navigate(typeof(HubSettingsPage), null, new DrillInNavigationTransitionInfo());
+
+    }
 }

--- a/HouzLinc/Views/Scenes/SceneListPage.xaml
+++ b/HouzLinc/Views/Scenes/SceneListPage.xaml
@@ -103,9 +103,37 @@
                 BorderThickness="0"/>
         </StackPanel>
 
+        <!-- No scene to show -->
+        <StackPanel
+            x:Name="EmptyListView"
+            x:Load="{x:Bind sceneListViewModel.IsEmpty, Mode=OneWay}"
+            Grid.Row="2"
+            Margin="10,15,10,0">
+            <StackPanel x:Name="HubNotFound" x:Load="{x:Bind settingsViewModel.IsHubNotFound}">
+                <TextBlock TextWrapping="Wrap" Text="The hub was not found on your local network!"/>
+                <TextBlock Margin="0,15,0,0">
+                    <Span xml:space="preserve">Please <Hyperlink Click="NavigateToHubSettings">review the hub information</Hyperlink></Span>
+                    .</TextBlock>
+            </StackPanel>
+            <StackPanel x:Name="HubFound" x:Load="{x:Bind settingsViewModel.IsHubFound}">
+                <TextBlock TextWrapping="Wrap" Text="There is no scene to show here yet! "/>
+                <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="You can create a new scene by tapping:"/>
+                <Button
+                    Tag="AddScene"
+                    win:ToolTipService.ToolTip="Add Scene"
+                    Margin="0,4,0,0"
+                    Style="{ThemeResource SplitViewPaneButtonStyle}"
+                    Click="AddSceneBtnClick">
+                    <SymbolIcon Symbol="Add"/>
+                </Button>
+                <TextBlock TextWrapping="Wrap">either here or at top right of this page.</TextBlock>
+            </StackPanel>
+        </StackPanel>
+
         <!-- List of scenes -->
         <ListView
             x:Name="SceneListView"
+            Visibility="{x:Bind sceneListViewModel.IsEmpty, Converter={StaticResource VisibilityNegation}, Mode=OneWay}"
             Grid.Row="2"
             Margin="5,0,5,2"
             EntranceNavigationTransitionInfo.IsTargetElement="True"

--- a/HouzLinc/Views/Scenes/SceneListPage.xaml.cs
+++ b/HouzLinc/Views/Scenes/SceneListPage.xaml.cs
@@ -13,12 +13,12 @@
    limitations under the License.
 */
 
-using System.Collections.ObjectModel;
 using ViewModel.Scenes;
 using HouzLinc.Views.Base;
 using HouzLinc.Dialogs;
 using ViewModel.Settings;
-using ViewModel.Base;
+using Microsoft.UI.Xaml.Media.Animation;
+using HouzLinc.Views.Settings;
 
 namespace HouzLinc.Views.Scenes;
 
@@ -57,6 +57,9 @@ public sealed partial class SceneListPage : SceneListPageBase
     private SceneListViewModel? itemsListViewModel;
     private SceneListViewModel sceneListViewModel => (ItemListViewModel as SceneListViewModel)!;
 
+    // Additional view model referenced on this page
+    private SettingsViewModel settingsViewModel => SettingsViewModel.Instance;
+
     private async void AddSceneBtnClick(object sender, RoutedEventArgs e)
     {
         if (XamlRoot == null)
@@ -85,5 +88,10 @@ public sealed partial class SceneListPage : SceneListPageBase
                 SelectedItem = null;
             }
         }
+    }
+
+    private void NavigateToHubSettings(Microsoft.UI.Xaml.Documents.Hyperlink sender, Microsoft.UI.Xaml.Documents.HyperlinkClickEventArgs args)
+    {
+        (App.MainWindow.Content as AppShell)?.Navigate(typeof(HubSettingsPage), null, new DrillInNavigationTransitionInfo());
     }
 }

--- a/HouzLinc/Views/Settings/HubSettingsPage.xaml
+++ b/HouzLinc/Views/Settings/HubSettingsPage.xaml
@@ -40,12 +40,12 @@
         <ScrollViewer Grid.Row="1" Margin="0,10,0,10">
             <StackPanel Margin="10,0,20,0">
                 <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="HouzLinc needs some information about your Insteon Hub to access your Insteon network."/>
-                <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="Please enter the information marked * below and click 'Find&#160;Hub'. You will find that information on the back of your Insteon Hub."/>
-                <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="If the hub is not found, look up its IP address on your local network. You can usually find that information in your router app/portal. Enter the IP address and click 'Find&#160;Hub' again."/>
+                <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="Please enter the information marked * below and tap 'Find&#160;Hub'. You will find that information on the back of your Insteon Hub."/>
+                <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Text="If the hub is not found, look up its IP address on your local network. You can usually find that information in your router app/portal. Enter the IP address and tap 'Find&#160;Hub' again."/>
                 <local:HubSettingsView Margin="0,15,0,0" Content="{x:Bind SettingsViewModel}"/>
-                <TextBlock Margin="0,15,0,0" Visibility="{x:Bind SettingsViewModel.IsHubFound, Mode=OneWay}">
+                <TextBlock Margin="0,15,0,0" Visibility="{x:Bind SettingsViewModel.IsHubFound, Mode=OneWay}" TextWrapping="Wrap">
                     Click<Span xml:space="preserve"> <Hyperlink Click="NavigateToDevices">here</Hyperlink></Span>
-                    or select the 'Devices' tab to start adding or discovering devices.</TextBlock>
+                    or the "Devices" tab to start adding or discovering devices.</TextBlock>
             </StackPanel>
         </ScrollViewer>
 

--- a/HouzLinc/Views/Settings/SettingsPage.xaml
+++ b/HouzLinc/Views/Settings/SettingsPage.xaml
@@ -45,12 +45,12 @@
                     Margin="0,10,0,0"
                     TextWrapping="Wrap"
                     Visibility="{x:Bind SettingsViewModel.IsHubFound, Converter={StaticResource VisibilityNegation}, Mode=OneWay}"
-                    Text="Please enter the information marked * below and click 'Find&#160;Hub'. You will find that information on the back of your Insteon Hub."/>
+                    Text="Please enter the information marked * below and tap 'Find&#160;Hub'. You will find that information on the back of your Insteon Hub."/>
                 <TextBlock
                     Margin="0,10,0,0"
                     TextWrapping="Wrap"
                     Visibility="{x:Bind SettingsViewModel.IsHubFound, Converter={StaticResource VisibilityNegation}, Mode=OneWay}"
-                    Text="If the hub is not found, look up its IP address on your local network. You can usually find that information in your router app/portal. Enter the IP address and click 'Find&#160;Hub' again."/>
+                    Text="If the hub is not found, look up its IP address on your local network. You can usually find that information in your router app/portal. Enter the IP address and tap 'Find&#160;Hub' again."/>
 
                 <local:HubSettingsView Margin="0,15,0,15" Content="{x:Bind SettingsViewModel}"/>
 

--- a/HouzLinc/Views/Tools/ToolsPage.xaml
+++ b/HouzLinc/Views/Tools/ToolsPage.xaml
@@ -40,7 +40,7 @@
         <StackPanel Grid.Row="1" Margin="5,0,0,0">
             <StackPanel Orientation="Vertical" Margin="-12,0,0,0">
                 <HyperlinkButton Click="{x:Bind ToolsViewModel.ScheduleImportAllDevices}" FontWeight="SemiBold">
-                    Import house configuration from the Insteon network of devices.
+                    Discover device already in your Insteon network.
                 </HyperlinkButton>
                 <StackPanel Orientation="Horizontal" Visibility="{x:Bind ToolsViewModel.IsImportAllDevicesRunning, Mode=OneWay}">
                     <ProgressBar Width="96" Margin="10,2,10,0" IsIndeterminate="True"/>

--- a/Insteon/Model/Devices.cs
+++ b/Insteon/Model/Devices.cs
@@ -688,7 +688,7 @@ public sealed class Devices : OrderedKeyedList<Device>
             }
             else
             {
-                Logger.Log.RequestUserAction($"To wake up '{device.DisplayNameAndId}', please click 'Play' while holding any button down. Click 'X' to snooze the device.");
+                Logger.Log.RequestUserAction($"To wake up '{device.DisplayNameAndId}', please tap 'Play' while holding any button down. Tap 'X' to snooze the device.");
             }
         },
         force: true);

--- a/ViewModel/Base/ItemListViewModel.cs
+++ b/ViewModel/Base/ItemListViewModel.cs
@@ -19,8 +19,39 @@ namespace ViewModel.Base;
 
 public abstract class ItemListViewModel<ItemViewModelType> : PageViewModel where ItemViewModelType : ItemViewModel
 {
-    // List of ItemViewModel items
-    public abstract SortableObservableCollection<ItemViewModelType> Items { get; }
+    /// <summary>
+    /// Item collection
+    /// </summary>
+    public SortableObservableCollection<ItemViewModelType> Items
+    {
+        get
+        {
+            items ??= new();
+            items.CollectionChanged += (sender, e) =>
+            {
+                IsEmpty = items.Count == 0;
+            };
+            return items;
+        }
+    }
+    private SortableObservableCollection<ItemViewModelType>? items;
+
+    /// <summary>
+    /// UI Bindable property indicating whether the Items collection is empty
+    /// </summary>
+    public bool IsEmpty
+    {
+        get => isEmpty;
+        set
+        {
+            if (value != isEmpty)
+            {
+                isEmpty = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+    private bool isEmpty;
 
     /// <summary>
     /// Called when the page (view) had loaded

--- a/ViewModel/Devices/DeviceListViewModel.cs
+++ b/ViewModel/Devices/DeviceListViewModel.cs
@@ -13,6 +13,7 @@
    limitations under the License.
 */
 
+using System.Diagnostics;
 using Common;
 using Insteon.Model;
 using ViewModel.Base;
@@ -24,6 +25,14 @@ namespace ViewModel.Devices;
 // Also ensure constant time lookup by id
 public sealed class DeviceListViewModel : ItemListViewModel<DeviceViewModel>, IDevicesObserver, IRoomsObserver
 {
+    // A public default constructor is necessary to make the generated binding code compile
+    // but it should not be called as we should always instantiate it with a list of devices.
+    public DeviceListViewModel()
+    {
+        Debug.Assert(false, "DeviceListViewModel should always be created with a list of devices.");
+        this.devices = null!;
+    }
+
     private DeviceListViewModel(Insteon.Model.Devices devices, bool includeHub = false)
     {
         this.devices = devices;
@@ -57,12 +66,6 @@ public sealed class DeviceListViewModel : ItemListViewModel<DeviceViewModel>, ID
         RoomFilter = roomFilter;
         return this;
     }
-
-    /// <summary>
-    /// Item collection
-    /// </summary>
-    public override SortableObservableCollection<DeviceViewModel> Items => items ??= new();
-    private SortableObservableCollection<DeviceViewModel>? items;
 
     // To idenfity items in the SettingsStore
     protected override string ItemTypeName => "Device";

--- a/ViewModel/Devices/DeviceViewModel.cs
+++ b/ViewModel/Devices/DeviceViewModel.cs
@@ -612,13 +612,24 @@ public class DeviceViewModel : LinkHostViewModel, IDeviceObserver, IRoomsObserve
     protected virtual void OnDevicePropertyChanged(string propertyName)
     {
         OnPropertyChanged(propertyName);
-        if (propertyName == nameof(Device.Status))
+
+        switch (propertyName)
         {
-            OnPropertyChanged(nameof(DeviceConnectionStatus));
-            OnPropertyChanged(nameof(IsStatusPending));
-            OnPropertyChanged(nameof(IsConnected));
-            OnPropertyChanged(nameof(IsDisconnected));
-            OnPropertyChanged(nameof(IsGatewayError));
+            case nameof(Device.Status):
+                OnPropertyChanged(nameof(DeviceConnectionStatus));
+                OnPropertyChanged(nameof(IsStatusPending));
+                OnPropertyChanged(nameof(IsConnected));
+                OnPropertyChanged(nameof(IsDisconnected));
+                OnPropertyChanged(nameof(IsGatewayError));
+                break;
+
+            case nameof(Device.CategoryId):
+                OnPropertyChanged(nameof(ModelIconPath_72x72));
+                break;
+
+            case nameof(Device.SubCategory):
+                OnPropertyChanged(nameof(ModelIconPath_72x72));
+                break;
         }
     }
 

--- a/ViewModel/Hub/HubChannelListViewModel.cs
+++ b/ViewModel/Hub/HubChannelListViewModel.cs
@@ -45,12 +45,6 @@ public sealed class HubChannelListViewModel : ItemListViewModel<HubChannelViewMo
         return new HubChannelListViewModel(hub);
     }
 
-    /// <summary>
-    /// Item collection
-    /// </summary>
-    public override SortableObservableCollection<HubChannelViewModel> Items => items ??= new();
-    private SortableObservableCollection<HubChannelViewModel>? items;
-
     // To identify items in the SettingsStore
     protected override string ItemTypeName => "Scene";
 

--- a/ViewModel/Scenes/SceneListViewModel.cs
+++ b/ViewModel/Scenes/SceneListViewModel.cs
@@ -13,9 +13,7 @@
    limitations under the License.
 */
 
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
+using System.Diagnostics;
 using Insteon.Model;
 using ViewModel.Base;
 using ViewModel.Settings;
@@ -24,6 +22,14 @@ namespace ViewModel.Scenes;
 
 public class SceneListViewModel : ItemListViewModel<SceneViewModel>, IScenesObserver, IRoomsObserver
 {
+    // A public default constructor is necessary to make the generated binding code compile
+    // but it should not be called as we always instantiate it with a list of scenes.
+    public SceneListViewModel()
+    {
+        Debug.Assert(false, "SceneListViewModel should always be created with a list of scenes.");
+        this.scenes = null!;
+    }
+
     private SceneListViewModel(Insteon.Model.Scenes scenes)
     {
         this.scenes = scenes;
@@ -50,12 +56,6 @@ public class SceneListViewModel : ItemListViewModel<SceneViewModel>, IScenesObse
         RoomFilter = roomFilter;
         return this;
     }
-
-/// <summary>
-/// Item collection
-/// </summary>
-public override SortableObservableCollection<SceneViewModel> Items => items ??= new();
-    private SortableObservableCollection<SceneViewModel>? items;
 
     // To identify items in the SettingsStore
     protected override string ItemTypeName => "Scene";


### PR DESCRIPTION
This change adds UI guiding the user when we have not found the hub or have no device or scene yet. This tells the user where to go next to either add devices, discover devices on their network, or add scenes. In addition:
- Simplified initialization of Items in ListViewModels and added bindable IsEmpty to adapt the UI when the list of items (devices or scenes) is empty.
- Renamed "Click" to "Tap" in a few places to be a bit more mobile friendly. 
- Added property change notification when the device picture changes to populate the list of devices progressively while discovering devices.