### PR TITLE
Only record changes if needed.

### DIFF
--- a/Insteon/Model/House.cs
+++ b/Insteon/Model/House.cs
@@ -48,7 +48,7 @@ public sealed class House
     {
         // The model we are copying from is already the result of applying these changes
         // and we have no need to re-record them.
-        ModelRecorder.DisableRecording();
+        var wasRecording = ModelRecorder.StopRecording();
 
         Name = house.Name;
         Version = house.Version;
@@ -58,7 +58,7 @@ public sealed class House
         Scenes.CopyFrom(house.Scenes);
         Rooms ??= new Rooms(this);
 
-        ModelRecorder.EnableRecording();
+        if (wasRecording) ModelRecorder.StartRecording();
     }
 
     public bool IsIdenticalTo(House house)
@@ -96,7 +96,7 @@ public sealed class House
     /// <summary>
     /// Play recorded but yet unplayed changes to this model against a target model
     /// </summary>
-    public void PlayModel(House targetHouse)
+    public void PlayChanges(House targetHouse)
     {
         ModelRecorder.Play(targetHouse);
     }
@@ -130,9 +130,17 @@ public sealed class House
     }
 
     /// <summary>
-    /// Starts background sync of physical devices
+    /// Starts change recording changes to the model
     /// </summary>
-    public void Start()
+    public void StartRecordingChanges()
+    {
+        ModelRecorder.StartRecording();
+    }
+
+    /// <summary>
+    /// Start background sync of physical devices
+    /// </summary>
+    public void StartBackgroundDeviceSync()
     {
         Devices.StartBackgroundDeviceSync();
     }

--- a/Insteon/Model/ModelRecorder.cs
+++ b/Insteon/Model/ModelRecorder.cs
@@ -21,7 +21,7 @@ internal class ModelRecorder
     {
         lock (changes)
         {
-            if (!isRecordingDisabled)
+            if (isRecording)
             {
                 changes.Add(change);
             }
@@ -42,16 +42,18 @@ internal class ModelRecorder
         }
     }
 
-    internal void DisableRecording()
+    internal bool StopRecording()
     {
-        isRecordingDisabled = true;
+        var wasRecording = isRecording;
+        isRecording = false;
+        return wasRecording;
     }
 
-    internal void EnableRecording()
+    internal void StartRecording()
     {
-        isRecordingDisabled = false;
+        isRecording = true;
     }
 
     List<ModelChange> changes = new List<ModelChange>();
-    bool isRecordingDisabled;
+    bool isRecording;
 }

--- a/UnitTestApp/Insteon/ModelTestsBase.cs
+++ b/UnitTestApp/Insteon/ModelTestsBase.cs
@@ -34,6 +34,7 @@ public class ModelTestsBase
         var h = await ModelHolderForTest.LoadFromFile("Changes", filename);
         Assert.IsNotNull(h);
         house = h!;
+        house.StartRecordingChanges();
 
         // set this to true to save the model if an update is needed
 #if false
@@ -49,7 +50,7 @@ public class ModelTestsBase
     private protected async Task PlayAndCheck()
     {
         // Play the changes recorded while modifying model house against yet unmodified targetHouse
-        house.PlayModel(targetHouse);
+        house.PlayChanges(targetHouse);
 
         // Save the model that was modified directly
         // If this is different from the ref file stored in the ms-appx:///Refs folder,
@@ -70,7 +71,7 @@ public class ModelTestsBase
         // Play the changes recorded while modifying model house locally
         // against targetHouse in which we simulated changes from another instance of this app
         // This gives us the merged model with all changes
-        house.PlayModel(targetHouse);
+        house.PlayChanges(targetHouse);
 
         // Save the merged model
         // We can't use this as ref as it might be different than the ultimate working model

--- a/ViewModel/Settings/FileStorageProvider.cs
+++ b/ViewModel/Settings/FileStorageProvider.cs
@@ -104,7 +104,7 @@ public class FileStorageProvider : StorageProvider
         if (lastSavedHouse != null)
         {
             // Merge in our local changes since we last saved the model
-            house.PlayModel(lastSavedHouse);
+            house.PlayChanges(lastSavedHouse);
 
             // The result is a new model that is a merge of the last saved model and our local changes
             // We copy it back to our working house model, allowing UI notificaitons for what may have changed

--- a/ViewModel/Settings/Holder.cs
+++ b/ViewModel/Settings/Holder.cs
@@ -66,8 +66,11 @@ public static class Holder
         // Listen for whether we are pushing network traffic through the gateway
         House.OnGatewayTraffic += (bool hasTraffic) => { HasGatewayTraffic = hasTraffic; };
 
-        // Start backgrounf sync of physical devices
-        House.Start();
+        // Start recording changes to the model
+        House.StartRecordingChanges();
+
+        // Start background sync between house model and physical devices
+        House.StartBackgroundDeviceSync();
     }
 
     /// <summary>

--- a/ViewModel/Settings/OneDriveStorageProvider.cs
+++ b/ViewModel/Settings/OneDriveStorageProvider.cs
@@ -130,7 +130,7 @@ internal class OneDriveStorageProvider : StorageProvider
                 if (lastSavedHouse != null)
                 {
                     // Merge in our local changes since we last saved the model
-                    house.PlayModel(lastSavedHouse);
+                    house.PlayChanges(lastSavedHouse);
 
                     // The result is a new model that is a merge of the last saved model and our local changes
                     // We copy it back to our working house model, allowing UI notificaitons for what may have changed


### PR DESCRIPTION
This change clarifies the ability to start/stop model change recording.
Recording now starts off, so that house models on which `House.StartRecordingChanges` is not called will not record. This prevents from doing unnecessary work for models used transiently, such as when saving the house configuration for example.
Renamed `House.PlayModel` to `PlayChanges` for clarity.