### PR TITLE
Make "Sync" and "Save" buttons in status bar optional

### DIFF
--- a/Common/DeferredExecution.cs
+++ b/Common/DeferredExecution.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Common;
+
+/// <summary>
+/// This helper class defers execution of an "Executor" method taking one parameter of any type until the end of a block
+/// </summary>
+/// <typeparam name="T">Type of the parameter</typeparam>
+
+public sealed class DeferredExecution<T> : IDisposable
+{
+    private readonly Action<T> executor;
+    private readonly T param;
+    private readonly Action<bool> deferExecution;
+
+    /// <summary>
+    /// <param name="executor">Executor method</param>
+    /// <param name="param">Parameter to pass to the Executor method</param>
+    /// <param name="deferExecutionCallback">callback to start or stop defering the execution. 
+    /// This allows the user of this class block execution of the executor when it is deferred.</param>
+    /// </summary>
+    public DeferredExecution(Action<T> executor, T param, Action<bool> deferExecutionCallback)
+    {
+        this.executor = executor;
+        this.param = param;
+        this.deferExecution = deferExecutionCallback;
+        deferExecutionCallback(true);
+    }
+
+    public void Dispose()
+    {
+        deferExecution(false);
+        executor(param);
+    }
+}

--- a/HouzLinc/App.xaml.cs
+++ b/HouzLinc/App.xaml.cs
@@ -33,21 +33,31 @@ public partial class App : Application
                         // Load configuration information from appsettings.json
                         .EmbeddedSource<App>()
                         .Section<Msal>()
+                        .Section<FeatureFlags>()
                 );
                 // Register a service to get the configuration
                 host.ConfigureServices((context, services) => 
                     // Register view model
-                    services.AddTransient<MsalConfiguration>()
+                    services
+                        .AddTransient<MsalConfiguration>()
+                        .AddTransient<FeatureFlagsConfiguration>()
                 );
             });
 
         var host = appBuilder.Build();
 
-        // Get MSAL configuration using the Configuration service registered above
+        // Get MSAL configuration using the service registered above
         var msalConfiguration = host.Services.GetRequiredService<MsalConfiguration>();
         if (msalConfiguration != null)
         {
             OneDrive.Instance.SetMsalConfiguration(msalConfiguration);
+        }
+
+        // Get the feature flags configuration using the service registered above
+        var featureFlagsConfiguration = host.Services.GetRequiredService<FeatureFlagsConfiguration>();
+        if (featureFlagsConfiguration != null)
+        {
+            SettingsViewModel.Instance.SetFeatureFlagsConfiguration(featureFlagsConfiguration);
         }
 
         MainWindow = appBuilder.Window;

--- a/HouzLinc/Controls/StatusBar.xaml
+++ b/HouzLinc/Controls/StatusBar.xaml
@@ -18,7 +18,6 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
         <TextBlock
             Margin="10,3,10,3"
@@ -52,29 +51,31 @@
             Grid.Column="3"
             Tag="SyncHouse"
             win:ToolTipService.ToolTip="Sync House Configuration Progress"
-            Margin="0,3,2,3"
+            Margin="0,3,5,3"
             Width="24"
             Height="24"
             Background="LightGray"
-            IsActive="{x:Bind HasGatewayTraffic, Mode=OneWay}"/>
+            IsActive="{x:Bind settingsViewModel.HasGatewayTraffic, Mode=OneWay}"/>
         <Button
-            Grid.Column="4"
+            Grid.Column="3"
             Tag="SyncHouse"
             win:ToolTipService.ToolTip="Sync House Configuration"
-            Margin="0,3,2,3"
+            Margin="0,3,5,3"
             Style="{ThemeResource SplitViewPaneButtonStyle}"
-            IsEnabled="{x:Bind DoesHouseConfigNeedSync, Mode=OneWay}"
-            Click="SyncHouseConfig">
+            Visibility="{x:Bind settingsViewModel.ShowHouseSyncButton, Mode=OneWay}"
+            IsEnabled="{x:Bind settingsViewModel.DoesHouseConfigNeedSync, Mode=OneWay}"
+            Click="{x:Bind settingsViewModel.SyncHouse}">
             <SymbolIcon Symbol="Sync"/>
         </Button>
         <Button
-            Grid.Column="5"
+            Grid.Column="4"
             x:Name="SaveHouse"
             win:ToolTipService.ToolTip="Save House Configuration"
-            Margin="2,3,5,3"
+            Margin="0,3,5,3"
             Style="{ThemeResource SplitViewPaneButtonStyle}"
-            IsEnabled="{x:Bind DoesHouseConfigNeedSave, Mode=OneWay}"
-            Click="SaveHouseConfig">
+            Visibility="{x:Bind settingsViewModel.ShowHouseSaveButton}"
+            IsEnabled="{x:Bind settingsViewModel.DoesHouseConfigNeedSave, Mode=OneWay}"
+            Click="{x:Bind settingsViewModel.SaveHouse}">
             <SymbolIcon Symbol="Save"/>
         </Button>
     </Grid>

--- a/HouzLinc/Controls/StatusBar.xaml.cs
+++ b/HouzLinc/Controls/StatusBar.xaml.cs
@@ -66,56 +66,7 @@ public sealed partial class StatusBar : ContentControl, INotifyPropertyChanged
     public static readonly DependencyProperty IsUserActionRequestProperty =
         DependencyProperty.Register(nameof(IsUserActionRequest), typeof(bool), typeof(StatusBar), new PropertyMetadata(false));
 
-    /// <summary>
-    /// One way bindable to UI to indicate the house config needs saving
-    /// TODO: this is temporary to allow user control over saving to model file
-    /// Should be automatic in the future
-    /// </summary>
-    public bool DoesHouseConfigNeedSave => SettingsViewModel.Instance.DoesHouseConfigNeedSave;
-
-    /// <summary>
-    /// One way bindable to UI to indicate the house config needs syncing
-    /// TODO: this is temporary to allow user control over the sync process
-    /// Should be automatic in the future
-    /// </summary>
-    public bool DoesHouseConfigNeedSync => SettingsViewModel.Instance.DoesHouseConfigNeedSync;
-
-    /// <summary>
-    /// One way bindable to UI to indicate we are pushing traffic through the gateway
-    /// </summary>
-    public bool HasGatewayTraffic => SettingsViewModel.Instance.HasGatewayTraffic;
-
-    // Property changed notifications for properties above
-    private void OnViewModelPropertyChanged(string? propertyName)
-    {
-        switch (propertyName)
-        {
-            case nameof(SettingsViewModel.DoesHouseConfigNeedSave):
-                OnPropertyChanged(nameof(DoesHouseConfigNeedSave));
-                break;
-
-            case nameof(SettingsViewModel.DoesHouseConfigNeedSync):
-                OnPropertyChanged(nameof(DoesHouseConfigNeedSync));
-                break;
-
-            case nameof(SettingsViewModel.HasGatewayTraffic):
-                OnPropertyChanged(nameof(HasGatewayTraffic));
-                break;
-        }
-    }
-
-    // Actions from the buttons in the status bar.
-    // TODO: these should really be events fired by this StatusBar control
-    // and handled by the parent page
-    private async void SaveHouseConfig(object sender, RoutedEventArgs e)
-    {
-        await SettingsViewModel.Instance.SaveHouse();
-    }
-
-    private void SyncHouseConfig(object sender, RoutedEventArgs e)
-    {
-        SettingsViewModel.Instance.SyncHouse();
-    }
+    private SettingsViewModel settingsViewModel = SettingsViewModel.Instance;
 
     private void ConfirmUserAction(object sender, RoutedEventArgs e)
     {

--- a/Insteon/Drivers/DeviceDriver.cs
+++ b/Insteon/Drivers/DeviceDriver.cs
@@ -360,10 +360,10 @@ internal class DeviceDriver : DeviceDriverBase
     internal async override Task<bool> TryWriteRampRateAsync(byte rampRate)
     {
         bool success = true;
-        if (!await TryReadOnLevelAsync() || rampRate != RampRate)
+        if (!await TryReadRampRateAsync() || rampRate != RampRate)
         {
             success = false;
-            var command = new SetOnLevelForGroupCommand(House.Gateway, Id, group: 1, rampRate) { MockPhysicalDevice = House.GetMockPhysicalDevice(Id) };
+            var command = new SetRampRateForGroupCommand(House.Gateway, Id, group: 1, rampRate) { MockPhysicalDevice = House.GetMockPhysicalDevice(Id) };
             if (await command.TryRunAsync(maxAttempts: 15))
             {
                 this.RampRate = rampRate;


### PR DESCRIPTION
With this change we make the "Sync" and "Save" buttons on the bottom right of the window an optional feature, designed mostly for debug. These buttons introduce a user confirmation for syncing the house configuration with network devices or saving the house configuration to a local or online file. They are intended to help the developer confirm the state before syncing or saving when working on features under development.

These buttons can be shown and enabled by adding the following to `appsettings.json`:
```
  "FeatureFlags": {
    "EnableHouseSaveButton": true,
    "EnableHouseSyncButton": true,
  },
```

Details:
- Now obtain whether to show "Sync" and "Save" button in status bar using `appsettings.json`.
- Hide and show button appropriately and directly trigger the "Sync" or "Save" on model changes if not shown. 
- Add some debouncing logic to avoid saving too often.
- Improved `UpdatePropertiesSyncStatus` (in Device and Channel) to distinguish between model change and device sync and defer calling it when setting multiple properties in a row.
- Removed unnecessary properties and methods from `StatusBar.xaml.cs` and use the `SettingsViewModel` directly instead.
- Fixed bugs in implementation of `TryWriteRampRateAsync`.