### PR TITLE
Fix: device would not show connected after pressing the Connect button

### DIFF
--- a/Insteon/Base/Gateway.cs
+++ b/Insteon/Base/Gateway.cs
@@ -158,7 +158,7 @@ public sealed class Gateway
                 string base64 = Base64Encode(Username + ":" + Password);
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64);
                 //httpClient.DefaultRequestHeaders.IfModifiedSince = new DateTimeOffset(DateTime.Now.AddDays(-1));
-                httpClient.DefaultRequestHeaders.ConnectionClose = true;
+                //httpClient.DefaultRequestHeaders.ConnectionClose = true;
                 httpClient.Timeout = TimeSpan.FromSeconds(5);
             }
             return httpClient;

--- a/Insteon/Model/Device.cs
+++ b/Insteon/Model/Device.cs
@@ -1147,8 +1147,7 @@ public sealed class Device : DeviceBase
                     {
                         // And run all callbacks on success
                         pingJob = null;
-                        isConnectionStatusKnown = true;
-                        Status = status;
+                        SetKnownConnectionStatus(status);
                         var callbacks = new List<ConnectionStatusCallback>(connectionStatusCallbacks);
                         connectionStatusCallbacks.Clear();
                         callbacks.ForEach(c => c.Invoke(Status));
@@ -1662,12 +1661,21 @@ public sealed class Device : DeviceBase
         // And ping the device if we have not already
         if (!isConnectionStatusKnown)
         {
-            Status = await TryPingAsync();
-            isConnectionStatusKnown = true;
+            SetKnownConnectionStatus(await TryPingAsync());
         }
         return Status;
     }
     private bool isConnectionStatusKnown = false;
+
+    /// <summary>
+    /// Helper to set a known (just acquired) connection status
+    /// </summary>
+    /// <param name="status">Connection status to set</param>
+    internal void SetKnownConnectionStatus(ConnectionStatus status)
+    {
+        Status = status;
+        isConnectionStatusKnown = true;
+    }
 
     /// <summary>
     /// Acquire the product information data from the device if we don't have it already.

--- a/Insteon/Model/Devices.cs
+++ b/Insteon/Model/Devices.cs
@@ -890,6 +890,9 @@ public sealed class Devices : OrderedKeyedList<Device>
                     var hub = GetDeviceByID(House.Gateway.DeviceId);
                     hub?.AllLinkDatabase.ResetSyncStatus();
 
+                    // Record that this device is known to be connected
+                    device.SetKnownConnectionStatus(Device.ConnectionStatus.Connected);
+
                     deviceWithIsNew.Device = device;
                 }
 
@@ -966,6 +969,9 @@ public sealed class Devices : OrderedKeyedList<Device>
                     // and acquire link just added for the new device
                     var hub = GetDeviceByID(House.Gateway.DeviceId);
                     hub?.AllLinkDatabase.ResetSyncStatus();
+
+                    // Record that this device is known to be connected
+                    device.SetKnownConnectionStatus(Device.ConnectionStatus.Connected);
 
                     deviceWithIsNew.Device = device;
                 }


### PR DESCRIPTION
When a device showed "not connected" and the connect button was pressed, the device would be connected but the status would not be refreshed on screen. This is because the `isKnownConnectionStatus` is set to true, preventing `ScheduleGetConnectionStatus` from acquiring the new status.

This change sets the connection status directly when adding or connecting a device, since we already know at this point that the device is connected and therefore do not have to rely on `ScheduleGetConnectionStatus` in that case.

Since we can also set the `isKnownConnectionStatus` flag in that case, in addition to the status, I added a small helper function to set both callable from all the places where we set a known connection status.
