### PR TITLE
Fixed crash when adding a new gateway device

### DIFF
--- a/ViewModel/Devices/DeviceListViewModel.cs
+++ b/ViewModel/Devices/DeviceListViewModel.cs
@@ -417,7 +417,10 @@ public sealed class DeviceListViewModel : ItemListViewModel<DeviceViewModel>, ID
 
     void IDevicesObserver.DeviceInserted(int seq, Device device)
     {
-        throw new NotImplementedException("Devices should be added at end of device list, inserting is not supported");
+        // At the moment this only works for inserting the hub at the begining of the list
+        // which has no impact on the view.
+        if (seq != 0 || !device.IsHub)
+            throw new NotImplementedException("Devices should be added at end of device list, inserting is not supported");
     }
 
     void IDevicesObserver.DeviceRemoved(Device device)


### PR DESCRIPTION
Adding a new hub sends a DeviceInserted notification to the device view and this would trip an exception in all cases. In fact, we can handle that notification for a hub since there is no view change for adding a new hub. We also enforce that the hub device is added at the top of the list. 