### PR TITLE
Fixed a number of issues that prevented the app to work on WASM

### DIFF
--- a/HouzLinc/Views/Devices/DeviceTemplateSelector.cs
+++ b/HouzLinc/Views/Devices/DeviceTemplateSelector.cs
@@ -24,19 +24,20 @@ public sealed class DeviceTemplateSelector : DataTemplateSelector
     {
         if (item != null && item is DeviceViewModel dvm)
         {
-#if !DESKTOP
-            // On WindowsAppSDK, WASM, Android, iOS, "container" is the DeviceViews content control
-            var dv = container as DeviceView;
+#if DESKTOP || __WASM__
+            // On Desktop and WASM, "container" is the ContentPresenter.
+            // Either its TemplatedParent or Parent contains the DeviceView with the template resource.
+            // Note that TemplatedParent and Parent can sometimes be null (not sure exactly when).
+            // We ignore the call and return null in that case. We will get called back.
+            var dv = (container is ContentPresenter cp) ? (cp.TemplatedParent ?? cp.Parent) as DeviceView : null;
 #else
-            // On Desktop, "container" is the ContentPresenter
-            var dv = (container is ContentPresenter cp) ? cp.TemplatedParent as DeviceView : null;
+            // On WindowsAppSDK, Android, iOS, "container" is the DeviceViews content control
+            var dv = container as DeviceView;
 #endif
             if (dv != null)
             {
                 return (DataTemplate)dv.Resources[dvm.DeviceTemplateName];
             }
-
-            Debug.Assert(false, $"{nameof(DeviceTemplateSelector)}.SelectTemplateCore: Unexpected container type");
         }
         return null;
     }}

--- a/HouzLinc/Views/Links/LinkHostViews.xaml.cs
+++ b/HouzLinc/Views/Links/LinkHostViews.xaml.cs
@@ -38,12 +38,15 @@ public sealed class LinkListViewTemplateSelector : DataTemplateSelector
     {
         if (item != null)
         {
-#if !DESKTOP
+#if DESKTOP || __WASM__
+            // On Desktop or WASM, "container" is the ContentPresenter.
+            // Either its TemplatedParent or Parent contains the LinkHostView with the template resource.
+            // Note that TemplatedParent and Parent can sometimes be null (not sure exactly when).
+            // We ignore the call and return null in that case. We will get called back.
+            var lhv = (container is ContentPresenter cp) ? (cp.TemplatedParent ?? cp.Parent) as LinkHostViews : null;
+#else
             // On WindowsAppSDK, WASM, Android, iOS, "container" is the LinkHostViews content control
             var lhv = container as LinkHostViews;
-#else
-            // On Desktop, "container" is the ContentPresenter
-            var lhv = (container is ContentPresenter cp) ? cp.TemplatedParent as LinkHostViews : null;
 #endif
             if (lhv != null)
             {
@@ -62,8 +65,6 @@ public sealed class LinkListViewTemplateSelector : DataTemplateSelector
                 }
                 return (DataTemplate)lhv.Resources[resourceName];
             }
-
-            Debug.Assert(false, "Unexpected container type in SelectTemplateCore");
         }
         return null;
     }

--- a/ViewModel/Settings/OneDrive.cs
+++ b/ViewModel/Settings/OneDrive.cs
@@ -88,7 +88,7 @@ public sealed class OneDrive
     // TODO: use #if DESKTOP once this code is moved to the main project
     private const string redirectUri1 = "http://localhost:44321/";
 #elif __WASM__
-    private const string redirectUri1 = "http://localhost:5000/";
+    private const string redirectUri1 = "http://localhost:5000/authentication/login-callback.htm";
 #elif WINDOWS
     // Sometimes Microsoft requires the localhost URL instead of the nativeclient one.
     // I am not sure when and why and in any case both are registered with the app on Azure.


### PR DESCRIPTION
Some issues were preventing the app to work on WASM
- The redirect URL for OneDrive authentication was incorrect
- On WASM, the `SelectTemplateCore` method `container` parameter passes in the `ContentPresenter`, not its container as on Windows and Android.
- That method can also be called with `TemplatedParent` on the `ContentPresenter`. Sometimes `Parent` is not null and can be used, sometimes both are null and all we can do is return with no template (null). We seem to be called again in that case. Note that this seems to be specific to WASM. These situations don't occur with WindowsAppSdk or on Android as far as I can tell.