### PR TITLE
Fixed target framework version number

### DIFF
--- a/UnitTestApp/UnitTestApp.csproj
+++ b/UnitTestApp/UnitTestApp.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Uno.Sdk">
+﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>UnitTestApp</RootNamespace>
     <Platforms>x86;x64;ARM64</Platforms>


### PR DESCRIPTION
Target Framework version number had an extra ".0" at the end that was breaking the command line build.