### PR TITLE
Fixed overactive assert and a bug in a conditional.

### DIFF
--- a/Insteon/Model/Channel.cs
+++ b/Insteon/Model/Channel.cs
@@ -365,7 +365,7 @@ public sealed class Channel : ChannelBase
 
         if (!ArePropertiesRead)
         {
-            if (PropertiesSyncStatus == SyncStatus.Synced)
+            if (!afterSync)
                 PropertiesSyncStatus = SyncStatus.Changed;
         }
         else if (
@@ -378,7 +378,7 @@ public sealed class Channel : ChannelBase
         {
             PropertiesSyncStatus = SyncStatus.Synced;
         }
-        else
+        else if (PropertiesSyncStatus != SyncStatus.Changed)
         {
             PropertiesSyncStatus = afterSync ? SyncStatus.Unknown : SyncStatus.Changed;
         }


### PR DESCRIPTION
In Insteon.Device.UpdatePropertiesSyncStatus :
Fixed overactive assert 
Fixed logic to ensure that that we set the sync status properly when we don't have a device driver or have not read the properties from the physical device, and when we have properties, but the values differ between model and physical device.
Refer to the comments in the code for details.