### PR TITLE
Fixed a couple issues targeting "Desktop" on Windows

### DIFF
--- a/UnoApp/AppShell.xaml
+++ b/UnoApp/AppShell.xaml
@@ -104,7 +104,7 @@
             <VisualStateGroup x:Name="TitleBarStates">
                 <VisualState x:Name="WideLayout">
                     <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{x:Bind NavView.CompactModeThresholdWidth}"/>
+                        <AdaptiveTrigger MinWindowWidth="{x:Bind CompactModeThresholdWidth}"/>
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="AppTitleBar.Margin" Value="34,0,0,0"/>

--- a/UnoApp/AppShell.xaml.cs
+++ b/UnoApp/AppShell.xaml.cs
@@ -148,14 +148,19 @@ public sealed partial class AppShell : Page, INotifyPropertyChanged
     /// </summary>
     public void SetTitleBar()
     {
+#if !DESKTOP
+        // https://github.com/unoplatform/uno/issues/15789
         App.MainWindow.ExtendsContentIntoTitleBar = true;
         App.MainWindow.SetTitleBar(AppTitleBar);
+#endif
     }
 
     // We use the width of the NavView pane in the compact form as the height of the titlebar,
     // with a default of 48 as we are loading things up before showing the NavView
     private double TitleBarHeight => NavView?.CompactPaneLength ?? 48;
-    
+
+    // Similarly, ensure we have a default CompactModeThresholdWidth before showing the NavView
+    private double CompactModeThresholdWidth => NavView?.CompactModeThresholdWidth ?? 480;
 
     /// <summary>
     /// Default keyboard focus movement for any unhandled keyboarding


### PR DESCRIPTION
Fixed a crash where the binding code was trying to dereference `NavView` before it was loaded. Added `AppShell.CompactModeThresholdWidth` to handle the null case. No exactly sure why this happened only for Desktop but this must have to do with the way this specific binding works. 
Also disabled expanding window content to overlap the title bar to have a custom title bar. This is not working on Desktop and yield incorrect rendering.