### PR TITLE
Used the Uno Toolkit to set the safe (uncovered) area on mobile

### DIFF
--- a/UnoApp/AppShell.xaml
+++ b/UnoApp/AppShell.xaml
@@ -6,6 +6,7 @@
     xmlns:local="using:UnoApp"
     xmlns:controls="using:UnoApp.Controls"
     xmlns:utils="using:UnoApp.Utils"
+    xmlns:utu="using:Uno.Toolkit.UI"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:android="http://uno.ui/android"
@@ -35,7 +36,7 @@
         </DataTemplate>
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" utu:SafeArea.Insets="All">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>

--- a/UnoApp/Package.appxmanifest
+++ b/UnoApp/Package.appxmanifest
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
   <!-- IMPORTANT: The value of "Publisher" is set by UnoApp.csproj. See that file for details. -->
   <Identity Name="HouzLinc" Publisher="CN=LakesideApps" Version="1.0.0.0" />

--- a/UnoApp/UnoApp.csproj
+++ b/UnoApp/UnoApp.csproj
@@ -41,6 +41,7 @@
       Configuration;
       Material;
       Navigation;
+      Toolkit;
     </UnoFeatures>
   </PropertyGroup>
 


### PR DESCRIPTION
This is using the Uno Toolkit SafeArea property to keep the content inside the "safe" (uncovered) area, so that we don't have anything under the top bar and properly handle the soft keyboard.