### PR TITLE
Improvement to New Device Dialog

### DIFF
--- a/UnoApp/Controls/DeviceIDBox.xaml.cs
+++ b/UnoApp/Controls/DeviceIDBox.xaml.cs
@@ -41,9 +41,6 @@ sealed partial class DeviceIDBox : UserControl, INotifyPropertyChanged
     }
     private bool isReadOnly = false;
 
-    // Is the value a valid InsteonID
-    public bool IsValueValid => Value != null && !Value.IsNull;
-
     /// <summary>
     /// Value of the control
     /// </summary>
@@ -61,13 +58,28 @@ sealed partial class DeviceIDBox : UserControl, INotifyPropertyChanged
         {
             idBox.OnPropertyChanged(nameof(Value));
             idBox.OnPropertyChanged(nameof(DeviceIDText));
-            idBox.OnPropertyChanged(nameof(IsValueValid));
+            idBox.IsValueValid = e.NewValue != null && e.NewValue is InsteonID id && !id.IsNull;
         }
     }
 
     public static readonly DependencyProperty ValueProperty =
-        DependencyProperty.Register("Value", typeof(InsteonID), typeof(DeviceIDBox), 
+        DependencyProperty.Register(nameof(Value), typeof(InsteonID), typeof(DeviceIDBox), 
             new PropertyMetadata(DependencyProperty.UnsetValue, new PropertyChangedCallback(OnValueChanged)));
+
+    /// <summary>
+    /// Whether the value of the control is a valid device ID
+    /// </summary>
+    public bool IsValueValid
+    {
+        get => (bool)GetValue(IsValueValidProperty);
+        set => SetValue(IsValueValidProperty, value);
+    }
+
+    // Is the value a valid InsteonID
+    // Register the IsValueValid dependency property
+    public static readonly DependencyProperty IsValueValidProperty =
+        DependencyProperty.Register(nameof(IsValueValid), typeof(bool), typeof(DeviceIDBox),
+            new PropertyMetadata(false));
 
     // Used to bind to the textbox in the XAML of this user control
     public string DeviceIDText => Value?.ToString() ?? string.Empty;

--- a/UnoApp/Dialogs/NewDeviceDialog.xaml
+++ b/UnoApp/Dialogs/NewDeviceDialog.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="Add New Device"
     PrimaryButtonText="Add"
-    IsPrimaryButtonEnabled="{x:Bind DeviceIdBox.IsValueValid, Mode=OneWay}"
+    IsPrimaryButtonEnabled="{x:Bind isInputEnabledAndValueValid, Mode=OneWay}"
     SecondaryButtonText="Cancel"
     PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
     SecondaryButtonClick="ContentDialog_SecondaryButtonClick">
@@ -29,14 +29,15 @@
             x:Name="DeviceIdBox"
             HorizontalAlignment="Center"
             Margin="0,0,0,0"
-            IsEnabled="{x:Bind isAutoDiscovering, Converter={StaticResource BoolNegation}, Mode=OneWay}"/>
+            IsValueValid="{x:Bind isValueValid, Mode=TwoWay}"
+            IsEnabled="{x:Bind isInputEnabled, Mode=OneWay}"/>
 
         <TextBlock Margin="0,20,0,0" Text="Or auto-discover the device: tap below, then walk to the device and press and hold its 'set' button." TextWrapping="Wrap"/>
         <Button
             Content="Auto-discover device"
             Margin="0,20,0,0"
             HorizontalAlignment="Center"
-            IsEnabled="{x:Bind isAutoDiscovering, Converter={StaticResource BoolNegation}, Mode=OneWay}"
+            IsEnabled="{x:Bind isInputEnabled, Mode=OneWay}"
             Click="AutoDiscover_Click"/>
     </StackPanel>
 </ContentDialog>

--- a/UnoApp/Dialogs/NewDeviceDialog.xaml.cs
+++ b/UnoApp/Dialogs/NewDeviceDialog.xaml.cs
@@ -160,14 +160,35 @@ public sealed partial class NewDeviceDialog : ContentDialog, INotifyPropertyChan
             {
                 deviceId = value;
                 OnPropertyChanged();
+                OnPropertyChanged(nameof(isInputEnabledAndValueValid));
             }
         }
     }
     InsteonID? deviceId;
 
-    // Whether we are in the process of auto-discovering the device,
-    // i.e., the StartAllLinking command was called
-    private bool isAutoDiscovering => autoDiscoveryJob != null;
+    /// <summary>
+    /// Private property tracking DeviceIdBox.IsValueValid.
+    /// so that we can show the Add button when the value is valid.
+    /// </summary>
+    private bool isValueValid
+    {
+        get => _isValueValid;
+        set
+        {
+            if (_isValueValid != value)
+            {
+                _isValueValid = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(isInputEnabledAndValueValid));
+            }
+        }
+    }
+    private bool _isValueValid;
+    
+    // Whether input is enabled in the dialog.
+    // It is not when autodiscovering or waiting to close.
+    private bool isInputEnabled => autoDiscoveryJob == null && canClose;
+    private bool isInputEnabledAndValueValid => isInputEnabled && isValueValid;
 
     // Auto-discovery job (aka, Add device manually, StartAllLinking command)
     private object? autoDiscoveryJob
@@ -181,7 +202,8 @@ public sealed partial class NewDeviceDialog : ContentDialog, INotifyPropertyChan
                 if (value != null)
                     DeviceIdBox.Value = null;
                 OnPropertyChanged();
-                OnPropertyChanged(nameof(isAutoDiscovering));
+                OnPropertyChanged(nameof(isInputEnabled));
+                OnPropertyChanged(nameof(isInputEnabledAndValueValid));
             }
         }
     }
@@ -197,7 +219,20 @@ public sealed partial class NewDeviceDialog : ContentDialog, INotifyPropertyChan
     private ContentDialogClosingDeferral? closingDeferral;
 
     // Whether the dialog can close
-    private bool canClose;
+    private bool canClose
+    {
+        get => _canClose;
+        set
+        {
+            if (value != _canClose)
+            {
+                _canClose = value;
+                OnPropertyChanged(nameof(isInputEnabled));
+                OnPropertyChanged(nameof(isInputEnabledAndValueValid));
+            }
+        }
+    }
+    private bool _canClose;
 
     // Dialog should show an error indicating prior failure and asking user to try again
     private bool showPriorError;


### PR DESCRIPTION
Ensure that input to the New Device Dialog is disabled when auto-discovering a device or when adding the device, with the exception of the Cancel button. 
This change introduces the following on the `NewDeviceDialog` view model:
- `isInputEnabled` which is true when input to the dialog is enabled
- `IsValueValid` which we promote from the underlying `DeviceIdBox`.
- `isInputEnabledAndValueValid` which is an OR of the previous ones.
And the UI is adapted to use these. 