### PR TITLE
Fixed hypothetical race condition 

### DIFF
--- a/ViewModel/Devices/DeviceListViewModel.cs
+++ b/ViewModel/Devices/DeviceListViewModel.cs
@@ -188,7 +188,7 @@ public sealed class DeviceListViewModel : ItemListViewModel<DeviceViewModel>, ID
                 DeviceViewModel? deviceViewModel = null;
                 if (d.device != null)
                 {
-                    deviceViewModel = DeviceViewModel.GetById(d.device.Id);
+                    deviceViewModel = DeviceViewModel.GetOrCreateById(d.device.House, d.device.Id);
                 }
                 completionCallback?.Invoke((deviceViewModel, d.isNew));
             },


### PR DESCRIPTION
Though in theory, adding a new device creates the `DeviceViewModel` via the `IDevicesObserver.DeviceAdded` implementation in `DeviceListViewModel` and so it should exist when the completion callback for ScheduleAddDeviceManually is called, but just in case... replacing the GetById by a GetOrCreateById.