### PR TITLE
Ensured no new device was created when cancelling out of New Device dialog.

### DIFF
--- a/UnoApp/Dialogs/NewDeviceDialog.xaml.cs
+++ b/UnoApp/Dialogs/NewDeviceDialog.xaml.cs
@@ -142,6 +142,7 @@ public sealed partial class NewDeviceDialog : ContentDialog, INotifyPropertyChan
                     DeviceViewModel = d.deviceViewModel;
                     DeviceId = d.deviceViewModel.Id;
                     DeviceIdBox.Value = d.deviceViewModel.Id;
+                    isNewDevice = d.isNew;
                     wasAutoDiscovered = true;
                 }
                 autoDiscoveryJob = null;


### PR DESCRIPTION
If the device was auto discovered, it would be added to the list of devices before "Add" was pressed in the dialog but not removed if the user cancelled out of the dialog. Fixed.