### PR TITLE
Improved design for Add, Remove, Replace, Copy devices and tested them

### DIFF
--- a/Insteon/Model/Devices.cs
+++ b/Insteon/Model/Devices.cs
@@ -876,6 +876,10 @@ public sealed class Devices : OrderedKeyedList<Device>
                 // from the IMAllLinking command, and try again later as part of device synchronization.
                 if (await device.TryReadProductDataAsync())
                 {
+                    // Observers might have to adjust to the new product data
+                    // (e.g., view model created when adding the device might have to change)
+                    observers.ForEach(o => o.DeviceTypeChanged(device));
+
                     // Channels may have changed as operating flags control the number of channels
                     // on a certain devices such as KeypadLinc for example
                     device.EnsureChannels();
@@ -961,6 +965,12 @@ public sealed class Devices : OrderedKeyedList<Device>
                 // from the IMAllLinking command, and try again later as part of device synchronization.
                 if (await device.TryReadProductDataAsync())
                 {
+                    // Observers might have to adjust to the new product data
+                    // (e.g., view model created when adding the device might have to change)
+                    observers.ForEach(o => o.DeviceTypeChanged(device));
+
+                    // Channels may have changed as operating flags control the number of channels
+                    // on a certain devices such as KeypadLinc for example
                     device.EnsureChannels();
 
                     // Force reading the properties of the new device

--- a/Insteon/Model/IDevicesObserver.cs
+++ b/Insteon/Model/IDevicesObserver.cs
@@ -20,5 +20,6 @@ public interface IDevicesObserver
     public void DeviceAdded(Device device);
     public void DeviceInserted(int seq, Device device);
     public void DeviceRemoved(Device device);
+    public void DeviceTypeChanged(Device device);
 }
 

--- a/Insteon/Model/ModelObserver.cs
+++ b/Insteon/Model/ModelObserver.cs
@@ -57,6 +57,11 @@ public sealed class ModelObserver :
         OnModelChanged?.Invoke();
     }
 
+    void IDevicesObserver.DeviceTypeChanged(Device device)
+    {
+        OnModelChanged?.Invoke();
+    }
+
     void IDevicesObserver.DeviceInserted(int seq, Device device)
     {
         modelChangePlayer.Record(new DeviceInsertedChange(seq, device));

--- a/UnoApp/Dialogs/NewDeviceDialog.xaml
+++ b/UnoApp/Dialogs/NewDeviceDialog.xaml
@@ -7,8 +7,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="Add New Device"
-    PrimaryButtonText="Add"
     IsPrimaryButtonEnabled="{x:Bind isInputEnabledAndValueValid, Mode=OneWay}"
     SecondaryButtonText="Cancel"
     PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
@@ -32,7 +30,7 @@
             IsValueValid="{x:Bind isValueValid, Mode=TwoWay}"
             IsEnabled="{x:Bind isInputEnabled, Mode=OneWay}"/>
 
-        <TextBlock Margin="0,20,0,0" Text="Or auto-discover the device: tap below, then walk to the device and press and hold its 'set' button." TextWrapping="Wrap"/>
+        <TextBlock Margin="0,20,0,0" Text="Or auto-discover the device: tap below, then walk to the device and press and hold its 'Set' button until the device emits a double beep." TextWrapping="Wrap"/>
         <Button
             Content="Auto-discover device"
             Margin="0,20,0,0"

--- a/UnoApp/Dialogs/NewDeviceDialog.xaml.cs
+++ b/UnoApp/Dialogs/NewDeviceDialog.xaml.cs
@@ -17,22 +17,25 @@ using Common;
 using ViewModel.Devices;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Insteon.Model;
 
 namespace UnoApp.Dialogs;
 
 public sealed partial class NewDeviceDialog : ContentDialog, INotifyPropertyChanged
 {
-    public NewDeviceDialog(XamlRoot xamlRoot, DeviceListViewModel deviceListViewModel, 
+    public NewDeviceDialog(XamlRoot xamlRoot, House house, string title, string primaryButtonText,
         InsteonID? showDeviceId = null, bool showPriorError = false)
     {
         this.InitializeComponent();
         this.Closing += DeviceIdDialog_Closing;
-        this.deviceListViewModel = deviceListViewModel;
+        this.house = house;
         this.XamlRoot = xamlRoot;
         this.canClose = true;
         this.DeviceId = showDeviceId;
         this.DeviceIdBox.Value = DeviceId;
         this.showPriorError = showPriorError;
+        this.Title = title;
+        this.PrimaryButtonText = primaryButtonText;
     }
 
     // Data bdinding to the UI
@@ -57,7 +60,7 @@ public sealed partial class NewDeviceDialog : ContentDialog, INotifyPropertyChan
             }
 
             canClose = false;
-            var job = deviceListViewModel.ScheduleAddOrConnectDevice(DeviceId,
+            var job = DeviceViewModel.ScheduleAddOrConnectDevice(DeviceId, house,
                 (d) =>
                 {
                     if (d.deviceViewModel != null)
@@ -93,7 +96,7 @@ public sealed partial class NewDeviceDialog : ContentDialog, INotifyPropertyChan
         {
             // We discovered a device, then user canceled, so remove it
             canClose = false;
-            deviceListViewModel.ScheduleRemoveDevice(DeviceViewModel.Id,
+            DeviceViewModel.ScheduleRemoveDevice(
                 (success) =>
                 {
                     if (success)
@@ -113,7 +116,7 @@ public sealed partial class NewDeviceDialog : ContentDialog, INotifyPropertyChan
         {
             // No point holding the dialog open since the user cancelled,
             // just fire and forget the cancellation
-            deviceListViewModel.ScheduleCancelAddDevice(autoDiscoveryJob);
+            DeviceViewModel.ScheduleCancelAddDevice(autoDiscoveryJob, house);
             canClose = true;
         }
         else 
@@ -134,7 +137,7 @@ public sealed partial class NewDeviceDialog : ContentDialog, INotifyPropertyChan
     // Start an IM linking operation 
     private void AutoDiscover_Click(object sender, RoutedEventArgs e)
     {
-        autoDiscoveryJob = deviceListViewModel.ScheduleAddDeviceManually(
+        autoDiscoveryJob = DeviceViewModel.ScheduleAddDeviceManually(house,
             (d) =>
             {
                 if (d.deviceViewModel != null)
@@ -213,8 +216,8 @@ public sealed partial class NewDeviceDialog : ContentDialog, INotifyPropertyChan
     // DeviceViewModel for the device that is bing added
     private DeviceViewModel? DeviceViewModel;
 
-    // List of deviceListViewModel to add new device to
-    private readonly DeviceListViewModel deviceListViewModel;
+    // Model to which the device is to be added
+    private readonly House house;
 
     // Closing defferal to delay closing until the device is added
     private ContentDialogClosingDeferral? closingDeferral;

--- a/UnoApp/Views/Devices/DeviceDetailsPage.xaml
+++ b/UnoApp/Views/Devices/DeviceDetailsPage.xaml
@@ -53,7 +53,7 @@
                     win:ToolTipService.ToolTip="Remove Device"
                     Margin="0,0,3,0"
                     Style="{ThemeResource SplitViewPaneButtonStyle}"
-                    Click="RemoveDeviceBtnClick">
+                    Click="RemoveDevice_Click">
                     <SymbolIcon Symbol="Delete"/>
                 </Button>
                 <Button
@@ -65,9 +65,9 @@
                         <MenuFlyout Placement="Bottom">
                             <MenuFlyoutItem Text="Read and Update Device" Click="{x:Bind ItemViewModel.ForceSyncDevice_Click}"/>
                             <MenuFlyoutItem Text="Check Connection Status" Click="{x:Bind ItemViewModel.ForceCheckDeviceConnectionStatus_Click}"/>
-                            <MenuFlyoutItem Text="Remove Device" Click="{x:Bind ItemViewModel.RemoveDevice_Click}"/>
-                            <MenuFlyoutItem Text="Replace Device" Click="{x:Bind ItemViewModel.ReplaceDevice_Click}"/>
-                            <MenuFlyoutItem Text="Copy Device" Click="{x:Bind ItemViewModel.CopyDevice_Click}"/>
+                            <MenuFlyoutItem Text="Remove Device" Click="{x:Bind RemoveDevice_Click}"/>
+                            <MenuFlyoutItem Text="Replace Device" Click="{x:Bind ReplaceDevice_Click}"/>
+                            <MenuFlyoutItem Text="Copy Device" Click="{x:Bind CopyDevice_Click}"/>
                             <MenuFlyoutItem Text="Remove Stale Controllers/Responders" Click="{x:Bind ItemViewModel.RemoveStaleLinks_Click}"/>
                             <MenuFlyoutItem Text="Remove Duplicate Controllers/Responders" Click="{x:Bind ItemViewModel.RemoveDuplicateLinks_Click}"/>
                             <MenuFlyoutItem Text="Ensure Hub is First Controller" Click="{x:Bind ItemViewModel.EnsureLinkToHubIsFirst_Click}"/>

--- a/UnoApp/Views/Devices/DeviceDetailsPage.xaml.cs
+++ b/UnoApp/Views/Devices/DeviceDetailsPage.xaml.cs
@@ -17,6 +17,7 @@ using UnoApp.Views.Base;
 using UnoApp.Dialogs;
 using ViewModel.Devices;
 using ViewModel.Settings;
+using Common;
 
 namespace UnoApp.Views.Devices;
 
@@ -49,29 +50,49 @@ public sealed partial class DeviceDetailsPage : DeviceDetailsPageBase
     // TODO: this should be made a string resource and fetch from the code and XAML as needed
     public string PageHeaderProperty => PageHeader;
     public const string PageHeader = "Device";
+
+    // TODO: Consider moving these to a more global place such as the MainWindow for example.
+    // showDeviceId prepopulates the dialog with the given device ID, null to not prepopulate.
+    // showPriorError shows an error message if the dialog was shown before and the device ID could not be resolved.
+    private async Task<InsteonID?> ShowNewDeviceDialog(string title, string primaryButtonText, InsteonID ? showDeviceId, bool showPriorError = false)
+    {
+        if (XamlRoot == null)
+        {
+            throw new InvalidOperationException("XamlRoot is null");
+        }
+
+        NewDeviceDialog dialog = new NewDeviceDialog(XamlRoot, Holder.House, title, primaryButtonText, showDeviceId, showPriorError);
+        if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+        {
+            return dialog.DeviceId;
+        }
+        return null;
+    }
+
+
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-    private async void AddDeviceBtnClick(object sender, RoutedEventArgs e)
+    private async void AddDevice_Click(object sender, RoutedEventArgs e)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
     {
         // Current not implemented - Detail page does not have Add button
         throw new NotImplementedException();
     }
 
-    private async void RemoveDeviceBtnClick(object sender, RoutedEventArgs e)
+    private async void RemoveDevice_Click(object sender, RoutedEventArgs e)
     {
         if (ItemViewModel != null)
         {
             var confirmDialog = new ConfirmDialog(XamlRoot)
             {
                 // TODO: localize
-                Title = $"About to Remove Device {ItemViewModel.DisplayName}",
+                Title = $"About to Remove Device {ItemViewModel.DisplayNameAndId}",
                 Content = "Are you sure you want to remove this device?"
             };
 
             if (await confirmDialog.ShowAsync())
             {
                 // Remove device from the model and navigate away from its view
-                ItemViewModel.RemoveDevice(success =>
+                ItemViewModel.ScheduleRemoveDevice(success =>
                 {
                     if (success)
                     {
@@ -81,4 +102,56 @@ public sealed partial class DeviceDetailsPage : DeviceDetailsPageBase
             }
         }
     }
+
+    // Handler for the "Replace Device" menu
+    public async void ReplaceDevice_Click(object sender, RoutedEventArgs e)
+    {
+        bool showPriorError = false;
+        InsteonID? replacementDeviceId = null;
+        while (true)
+        {
+            // Present the dialog to the user to enter/discover the id of the replacement device.
+            // If successfull, this will add the new device to the model and
+            // the corresponding new view model to this list if not already in.
+            replacementDeviceId = await ShowNewDeviceDialog($"Replace {ItemViewModel?.DisplayNameAndId} by Device", "Replace", replacementDeviceId, showPriorError);
+            if (replacementDeviceId == null || replacementDeviceId.IsNull)
+                break;
+
+            // If we have a view model for the replacement device, proceed with the replacement
+            var replacementDeviceViewModel = DeviceViewModel.GetOrCreateById(Holder.House, replacementDeviceId);
+            if (replacementDeviceViewModel != null && ItemViewModel != null)
+            {
+                ItemViewModel.ReplaceDevice(replacementDeviceId);
+                break;
+            }
+
+            // We could not add the device (e.g., device with the Id the user entered
+            // did not exist on the network). Try again.
+            showPriorError = true;
+        }
+    }
+
+    // Handler for the "Copy Device" menu
+    public async void CopyDevice_Click(object sender, RoutedEventArgs e)
+    {
+        bool showPriorError = false;
+        InsteonID? copyDeviceId = null;
+        while (true)
+        {
+            // See ReplaceDevice_Click for comments
+            copyDeviceId = await ShowNewDeviceDialog($"Copy {ItemViewModel?.DisplayNameAndId} to Device", "Copy", copyDeviceId, showPriorError);
+            if (copyDeviceId == null || copyDeviceId.IsNull)
+                break;
+
+            var copyDeviceViewModel = DeviceViewModel.GetOrCreateById(Holder.House, copyDeviceId);
+            if (copyDeviceViewModel != null && ItemViewModel != null)
+            {
+                ItemViewModel.CopyDevice(copyDeviceId);
+                break;
+            }
+
+            showPriorError = true;
+        }
+    }
+
 }

--- a/UnoApp/Views/Devices/DeviceListPage.xaml
+++ b/UnoApp/Views/Devices/DeviceListPage.xaml
@@ -65,7 +65,7 @@
                     win:ToolTipService.ToolTip="Add Device"
                     Margin="0,0,3,0"
                     Style="{ThemeResource SplitViewPaneButtonStyle}"
-                    Click="AddDeviceBtnClick">
+                    Click="{x:Bind AddDevice_Click}">
                     <SymbolIcon Symbol="Add"/>
                 </Button>
                 <Button
@@ -74,7 +74,7 @@
                     win:ToolTipService.ToolTip="Remove Device"
                     Margin="0,0,3,0"
                     Style="{ThemeResource SplitViewPaneButtonStyle}"
-                    Click="RemoveDeviceBtnClick">
+                    Click="{x:Bind RemoveDevice_Click}">
                     <SymbolIcon Symbol="Delete"/>
                 </Button>
                 <Button
@@ -87,9 +87,9 @@
                         <MenuFlyout Placement="Bottom">
                             <MenuFlyoutItem Text="Force Sync Device" Click="{x:Bind deviceListViewModel.PresentedItem.ForceSyncDevice_Click}"/>
                             <MenuFlyoutItem Text="Check Connection Status" Click="{x:Bind deviceListViewModel.PresentedItem.ForceCheckDeviceConnectionStatus_Click}"/>
-                            <MenuFlyoutItem Text="Remove Device" Click="{x:Bind deviceListViewModel.PresentedItem.RemoveDevice_Click}"/>
-                            <MenuFlyoutItem Text="Replace Device" Click="{x:Bind deviceListViewModel.PresentedItem.ReplaceDevice_Click}"/>
-                            <MenuFlyoutItem Text="Copy Device" Click="{x:Bind deviceListViewModel.PresentedItem.CopyDevice_Click}"/>
+                            <MenuFlyoutItem Text="Remove Device" Click="{x:Bind RemoveDevice_Click}"/>
+                            <MenuFlyoutItem Text="Replace Device" Click="{x:Bind ReplaceDevice_Click}"/>
+                            <MenuFlyoutItem Text="Copy Device" Click="{x:Bind CopyDevice_Click}"/>
                             <MenuFlyoutItem Text="Remove Stale Controllers/Responders" Click="{x:Bind deviceListViewModel.PresentedItem.RemoveStaleLinks_Click}"/>
                             <MenuFlyoutItem Text="Remove Duplicate Controllers/Responders" Click="{x:Bind deviceListViewModel.PresentedItem.RemoveDuplicateLinks_Click}"/>
                             <MenuFlyoutItem Text="Ensure Hub is First Controller" Click="{x:Bind deviceListViewModel.PresentedItem.EnsureLinkToHubIsFirst_Click}"/>
@@ -143,7 +143,7 @@
                         win:ToolTipService.ToolTip="Add Device"
                         Margin="0,4,0,0"
                         Style="{ThemeResource SplitViewPaneButtonStyle}"
-                        Click="AddDeviceBtnClick">
+                        Click="{x:Bind AddDevice_Click}">
                         <SymbolIcon Symbol="Add"/>
                     </Button>
                     <TextBlock Margin="0,10,0,0" TextWrapping="Wrap">

--- a/UnoApp/Views/Devices/DeviceListPage.xaml.cs
+++ b/UnoApp/Views/Devices/DeviceListPage.xaml.cs
@@ -49,14 +49,14 @@ public sealed partial class DeviceListPage : DeviceListPageBase
     // TODO: Consider moving these to a more global place such as the MainWindow for example.
     // showDeviceId prepopulates the dialog with the given device ID, null to not prepopulate.
     // showPriorError shows an error message if the dialog was shown before and the device ID could not be resolved.
-    private async Task<InsteonID?> ShowNewDeviceDialog(InsteonID? showDeviceId, bool showPriorError = false)
+    private async Task<InsteonID?> ShowNewDeviceDialog(string title, string primaryButtonText, InsteonID ? showDeviceId, bool showPriorError = false)
     {
         if (XamlRoot == null)
         {
             throw new InvalidOperationException("XamlRoot is null");
         }
 
-        NewDeviceDialog dialog = new NewDeviceDialog(XamlRoot, deviceListViewModel, showDeviceId, showPriorError);
+        NewDeviceDialog dialog = new NewDeviceDialog(XamlRoot, Holder.House, title, primaryButtonText, showDeviceId, showPriorError);
         if (await dialog.ShowAsync() == ContentDialogResult.Primary)
         {
             return dialog.DeviceId;
@@ -64,17 +64,12 @@ public sealed partial class DeviceListPage : DeviceListPageBase
         return null;
     }
 
-    private async Task<InsteonID?> ShowNewDeviceDialog()
-    {
-        return await ShowNewDeviceDialog(showDeviceId: null);
-    }
-
     private async Task<InsteonID?> ShowDeviceIdDialog()
     {
         if (XamlRoot == null)
         {
             throw new InvalidOperationException("XamlRoot is null");
-    }
+        }
 
         DeviceIdDialog dialog = new DeviceIdDialog(XamlRoot);
         if (await dialog.ShowAsync() == ContentDialogResult.Primary)
@@ -106,7 +101,6 @@ public sealed partial class DeviceListPage : DeviceListPageBase
         base.OnPageLoaded();
 
         // Setup callback into the UI layer for ViewModels to show dialogs
-        DeviceListViewModel.ShowNewDeviceDialogHandler += ShowNewDeviceDialog;
         DeviceListViewModel.ShowDeviceIdDialogHandler += ShowDeviceIdDialog;
     }
 
@@ -114,11 +108,11 @@ public sealed partial class DeviceListPage : DeviceListPageBase
     {
         base.OnPageUnloaded();
 
-        DeviceListViewModel.ShowNewDeviceDialogHandler -= ShowNewDeviceDialog;
         DeviceListViewModel.ShowDeviceIdDialogHandler -= ShowDeviceIdDialog;
     }
 
-    private async void AddDeviceBtnClick(object sender, RoutedEventArgs e)
+    // Handler for the "Add device" button
+    private async void AddDevice_Click(object sender, RoutedEventArgs e)
     {
         bool showPriorError = false;
         InsteonID? deviceId = null;
@@ -126,49 +120,45 @@ public sealed partial class DeviceListPage : DeviceListPageBase
         {
             // Present the dialog to the user to enter/discover the device Id.
             // If successfull, this will add the new device to the model and
-            // the corresponding new view model to this list if not already in.
-            deviceId = await ShowNewDeviceDialog(deviceId, showPriorError);
+            // add the corresponding new view model to this list if not already in.
+            deviceId = await ShowNewDeviceDialog("Add New Device", "Add", deviceId, showPriorError);
             if (deviceId == null || deviceId.IsNull)
+            {
+                // User cancelled out of the dialog
                 break;
+            }
 
+            // If we have a new device view model, select it and return
             var deviceViewModel = DeviceViewModel.GetOrCreateById(Holder.House, deviceId);
             if (deviceViewModel != null)
             {
-                // If we had preloaded a vanilla device view model for percieved responsiveness,
-                // remove it now
-                if (!deviceListViewModel.Items.Empty() && 
-                    deviceListViewModel.Items.Last().Id == deviceId)
-                {
-                    deviceListViewModel.Items.RemoveAt(deviceListViewModel.Items.Count - 1);
-                }
 
-                // Add the new device view model to the list showing on this page
-                deviceListViewModel.Items.Add(deviceViewModel);
-
-                // Select the new device
                 SelectedItem = deviceViewModel;
                 break;
             }
 
+            // We could not add the device (e.g., device with the Id the user entered
+            // did not exist on the network). Try again.
             showPriorError = true;
         }
     }
 
-    private async void RemoveDeviceBtnClick(object sender, RoutedEventArgs e)
+    // Handler for the "Remove Device" button
+    private async void RemoveDevice_Click(object sender, RoutedEventArgs e)
     {
         if (SelectedItem != null)
         {
             var confirmDialog = new ConfirmDialog(XamlRoot)
             {
                 // TODO: localize
-                Title = $"About to Remove Device {SelectedItem.DisplayName}",
+                Title = $"About to Remove Device {SelectedItem.DisplayNameAndId}",
                 Content = "Are you sure you want to remove this device?"
             };
 
             if (await confirmDialog.ShowAsync())
             {
                 // Remove this device and unselect it
-                deviceListViewModel.ScheduleRemoveDevice(SelectedItem.Id, success =>
+                SelectedItem.ScheduleRemoveDevice(success =>
                 {
                     if (success)
                     {
@@ -178,6 +168,60 @@ public sealed partial class DeviceListPage : DeviceListPageBase
                 
             }
         }
+    }
+
+    // Handler for the "Replace Device" menu item
+    private async void ReplaceDevice_Click(object sender, RoutedEventArgs e)
+    {
+        bool showPriorError = false;
+        InsteonID? replacementDeviceId = null;
+        while (true)
+        {
+            // Present the dialog to the user to enter/discover the id of the replacement device.
+            // If successfull, this will add the new device to the model and
+            // the corresponding new view model to this list if not already in.
+            replacementDeviceId = await ShowNewDeviceDialog($"Replace {SelectedItem?.DisplayNameAndId} by Device", "Replace", replacementDeviceId, showPriorError);
+            if (replacementDeviceId == null || replacementDeviceId.IsNull)
+                break;
+
+            // If we have a view model for the replacement device, proceed with the replacement
+            var relacementDeviceViewModel = DeviceViewModel.GetOrCreateById(Holder.House, replacementDeviceId);
+            if (relacementDeviceViewModel != null && SelectedItem != null)
+            {
+                SelectedItem.ReplaceDevice(replacementDeviceId);
+                SelectedItem = relacementDeviceViewModel;
+                break;
+            }
+
+            // We could not add the device (e.g., device with the Id the user entered
+            // did not exist on the network). Try again.
+            showPriorError = true;
+        }
+    }
+
+    // Handler for the "Copy Device" menu item
+    private async void CopyDevice_Click(object sender, RoutedEventArgs e)
+    {
+        bool showPriorError = false;
+        InsteonID? copyDevice = null;
+        while (true)
+        {
+            // See ReplaceDevice_Click for comments
+            copyDevice = await ShowNewDeviceDialog($"Copy {SelectedItem?.DisplayNameAndId} to Device", "Copy", copyDevice, showPriorError);
+            if (copyDevice == null || copyDevice.IsNull)
+                break;
+
+            var copyDeviceViewModel = DeviceViewModel.GetOrCreateById(Holder.House, copyDevice);
+            if (copyDeviceViewModel != null && SelectedItem != null)
+            {
+                SelectedItem.CopyDevice(copyDevice);
+                SelectedItem = copyDeviceViewModel;
+                break;
+            }
+
+            showPriorError = true;
+        }
+
     }
 
     private void NavigateToHubSettings(Microsoft.UI.Xaml.Documents.Hyperlink sender, Microsoft.UI.Xaml.Documents.HyperlinkClickEventArgs args)


### PR DESCRIPTION
This change improves the design for Add, Remove, Replace, and Copy Device. These operations need to throw some UI before execution. This is now done in the App/UI layer by binding the UI to the code behind the pages originating these operations, then control is passed to the View Model layer to complete the work. This simplifies the flow with no need to hop back from the View Model to the App/UI. 

In this change:
- Gathered Add, Remove, Replace, Copy Device functionality in `DeviceViewModel`. Since these operations are independent of the presented list view of devices (if any), I removed them from `DeviceListViewModel`.

- Now report to observers of the list of devices that the product data (type) of a device has changed. For example, a generic device can be created as placeholder for perceived performance and then changed to be a keypad. `DeviceListViewModel` listens to this notification and can recreate the device view model and swap it in the list. 

- Removed access to the New Device Dialog from the View Model layer. These are now only access from the App/UI (see above).

- Tested that these operations work as expected, and fixed a few issues.