### PR TITLE
Ensured that new Item is selected when adding, replacing, or moving a device or scene

### DIFF
--- a/UnoApp/Views/Base/ItemListPage.xaml.cs
+++ b/UnoApp/Views/Base/ItemListPage.xaml.cs
@@ -53,6 +53,7 @@ public abstract partial class ItemListPage<ItemViewModelType, ItemDetailsPage> :
     protected StatusBarViewModel StatusBarViewModel => StatusBarViewModel.Instance;
 
     // Currently selected item in the main view model
+    // Convenience but NOT bindable. Bind UI to ItemListViewModel.SelectedItem instead
     protected ItemViewModelType? SelectedItem
     {
         get => ItemListViewModel.SelectedItem;

--- a/UnoApp/Views/Devices/DeviceListPage.xaml
+++ b/UnoApp/Views/Devices/DeviceListPage.xaml
@@ -167,7 +167,7 @@
             IsItemClickEnabled="True"
             ItemClick="OnItemClick"
             ItemsSource="{x:Bind deviceListViewModel.Items, Mode=OneWay}"
-            SelectedItem="{x:Bind SelectedItem, Mode=TwoWay}"
+            SelectedItem="{x:Bind deviceListViewModel.SelectedItem, Mode=TwoWay}"
             ScrollViewer.HorizontalScrollBarVisibility="Auto"
             ScrollViewer.HorizontalScrollMode="Enabled"
             ItemContainerStyle="{StaticResource CustomListViewItemExpanded}">

--- a/UnoApp/Views/Devices/DeviceListPage.xaml.cs
+++ b/UnoApp/Views/Devices/DeviceListPage.xaml.cs
@@ -132,7 +132,6 @@ public sealed partial class DeviceListPage : DeviceListPageBase
             var deviceViewModel = DeviceViewModel.GetOrCreateById(Holder.House, deviceId);
             if (deviceViewModel != null)
             {
-
                 SelectedItem = deviceViewModel;
                 break;
             }

--- a/UnoApp/Views/Scenes/SceneListPage.xaml
+++ b/UnoApp/Views/Scenes/SceneListPage.xaml
@@ -154,7 +154,7 @@
             IsItemClickEnabled="True"
             ItemClick="OnItemClick"
             ItemsSource="{x:Bind sceneListViewModel.Items, Mode=OneWay}"
-            SelectedItem="{x:Bind SelectedItem, Mode=TwoWay}"
+            SelectedItem="{x:Bind sceneListViewModel.SelectedItem, Mode=TwoWay}"
             ScrollViewer.HorizontalScrollBarVisibility="Auto"
             ScrollViewer.HorizontalScrollMode="Enabled"
             ItemContainerStyle="{StaticResource CustomListViewItemExpanded}">


### PR DESCRIPTION
`ListView.SelectedItem` needs to be bound to the `DeviceViewModel.SelectedItem`, not the one in `DeviceListPage`, which is not firing `OnPropertyChanged`.