### PR TITLE
Fixed broken unit-tests after change #78 

### DIFF
--- a/UnitTestApp/Insteon/ModelTestsBase.cs
+++ b/UnitTestApp/Insteon/ModelTestsBase.cs
@@ -116,6 +116,7 @@ public static class HouseExtensions
         await house.Devices.AddOrConnectDeviceAsync(newDeviceId);
         var device = house.Devices.GetDeviceByID(newDeviceId)!;
         if (name != null) device.DisplayName = name;
+        await device.TryReadDevicePropertiesAsync(forceSync: true);
         await device.TryReadAllLinkDatabaseAsync();
         await house.Hub.TryReadAllLinkDatabaseAsync();
     }


### PR DESCRIPTION
Change #78 removed the immediate synchronization of the device so to improve perceived performance when discovering a new device. That broke a few unit-tests that depending on the synchronization status. Reintroduced that sync in `HouseExtensions.AddNewDevice` to keep the unit-tests behavior the same and keep them working. 