### PR TITLE
Unit-test depending on Debug Assert to succeed and failed in Release

### DIFF
--- a/Insteon/Model/AllLinkDatabase.cs
+++ b/Insteon/Model/AllLinkDatabase.cs
@@ -488,14 +488,14 @@ public sealed class AllLinkDatabase : OrderedNonUniqueKeyedList<AllLinkRecord>
     /// </summary>
     /// <param name="seq1">valid seq of first record to swap</param>
     /// <param name="seq2">valid seq of second record to swap</param>
-    internal void SwapRecords(int seq1, int seq2)
+    internal bool SwapRecords(int seq1, int seq2)
     {
         Debug.Assert(seq1 >= 0 && seq1 < Count);
         Debug.Assert(seq2 >= 0 && seq2 < Count);
 
         // Can't swap with high water mark
-        Debug.Assert(!this[seq1].IsHighWatermark);
-        Debug.Assert(!this[seq2].IsHighWatermark);
+        if (this[seq1].IsHighWatermark) return false;
+        if (this[seq2].IsHighWatermark) return false;
 
         // Remember the original records
         AllLinkRecord record1 = this[seq1];
@@ -511,6 +511,8 @@ public sealed class AllLinkDatabase : OrderedNonUniqueKeyedList<AllLinkRecord>
         this[seq1] = new(this[seq1]) { Uid = record2.Uid, SyncStatus = SyncStatus.Changed };
 
         LastStatus = SyncStatus.Changed;
+
+        return true;
     }
 
     /// <summary>

--- a/UnitTestApp/Insteon/TestAllLinkDatabase.cs
+++ b/UnitTestApp/Insteon/TestAllLinkDatabase.cs
@@ -289,14 +289,9 @@ public sealed class TestAllLinkDatabase
         AllLinkDatabase database = BuildDatabaseBefore();
         AllLinkDatabase referenceDatabase = BuildReferenceDatabaseAfterSwap();
 
-        database.SwapRecords(0, 1);
-        database.SwapRecords(2, 3);
-        try
-        {
-            database.SwapRecords(3, 5); // attempt to swap with high water mark, should fail
-            Assert.IsTrue(false, "Attempt to swap with high water mark should fail");
-        }
-        catch { }
+        Assert.IsTrue(database.SwapRecords(0, 1));
+        Assert.IsTrue(database.SwapRecords(2, 3));
+        Assert.IsFalse(database.SwapRecords(3, 5)); // attempt to swap with high water mark, should fail
 
         // Check records against reference
         Assert.AreEqual(referenceDatabase.Count, database.Count, "Test and ref databases have a different number of records");


### PR DESCRIPTION
Unit-Test `TestAllLinkDatabase_SwapRecords` depended on a `Debug.Assert` in `AllLinkDatabase.SwapRecords` to succeed and as a result failed in Release. Replaced the Assert by a bool return indicating success and adapted the unit-test.  