### PR TITLE
Fixed landing page for Add, Replace, Move Device commands in "narrow" mode. 

### DIFF
--- a/UnoApp/Views/Devices/DeviceDetailsPage.xaml
+++ b/UnoApp/Views/Devices/DeviceDetailsPage.xaml
@@ -49,6 +49,14 @@
                 Style="{StaticResource TitleTextBlockStyle}"/>
             <StackPanel Orientation="Horizontal" Grid.Column="1" VerticalAlignment="Center">
                 <Button
+                    Tag="AddDevice"
+                    win:ToolTipService.ToolTip="Add Device"
+                    Margin="0,0,3,0"
+                    Style="{ThemeResource SplitViewPaneButtonStyle}"
+                    Click="{x:Bind AddDevice_Click}">
+                    <SymbolIcon Symbol="Add"/>
+                </Button>
+                <Button
                     Tag="RemoveDevice"
                     win:ToolTipService.ToolTip="Remove Device"
                     Margin="0,0,3,0"


### PR DESCRIPTION
Navigate to the target page at the end of Replace and Remove Device commands in "narrow" mode (Device Detail page). Also added "Add Device" command to Device Detail page ("narrow mode").