### PR TITLE
Don't log group start message on every step for a stepped job

### DIFF
--- a/Common/Scheduler.cs
+++ b/Common/Scheduler.cs
@@ -531,8 +531,9 @@ public abstract class Scheduler
         {
             runCount++;
 
-            // If part of a group, notify job is starting
-            if (group != null)
+            // If part of a group and not a continuation step,
+            // notify the group that a job is starting
+            if (group != null && !isContinuationStep)
             {
                 group.NotifyJobStarting();
             }
@@ -655,8 +656,9 @@ public abstract class Scheduler
         {
             runCount++;
 
-            // If part of a group, notify job is starting
-            if (group != null)
+            // If part of a group and not a continuation step,
+            // notify the group that a job is starting
+            if (group != null && !isContinuationStep)
             {
                 group.NotifyJobStarting();
             }


### PR DESCRIPTION
When running a stepped job inside a group, the group start message was logged every step for a stepped job. It should only be logged once, at the start of the first step. This would create rapid blinking between different messages in the UX. Fixed.