### PR TITLE
Changed number of attempts for a command to 1 by default.

### DIFF
--- a/Insteon/Commands/Command.cs
+++ b/Insteon/Commands/Command.cs
@@ -201,10 +201,12 @@ public abstract class Command
     /// <summary>
     /// Max number of attempts of the command by default
     /// The default is 1 (no retry), so as to return to the scheduler as soon as possible
-    /// to decide whether to retry or cancel the job, potentially giving pending commands the opportunity to run.
-    /// A different number can be passed to TryRunAsync.
+    /// to decide whether to retry or cancel the job, potentially giving pending commands 
+    /// the opportunity to run first.
+    /// Certain commands (e.g., GetLink) that have a tendency to fail intermitently on some devices 
+    /// can pass a different number
     /// </summary>
-    internal const int DefaultMaxAttempts = 3;
+    internal const int DefaultMaxAttempts = 1;
 
     // Wait time before retrying after the command returns a error that could be due to network or device instability
     private static TimeSpan waitBeforeRetryAfterError = TimeSpan.FromMilliseconds(100);


### PR DESCRIPTION
The default number of attempts for a command was 3. That can make runs that fail repeatedly too long. Instead, we default that max attempt to 1 and let callers specify otherwise if they so desire. Note that the scheduler also has a default of 3 successive attempts for any job that fails, so we can rely on that to get past intermittent errors. This allows to run other command in between retries and make forward progress. 