### PR TITLE
Cleanup and small enhancements determining device Connection Status.

### DIFF
--- a/Insteon/Model/Devices.cs
+++ b/Insteon/Model/Devices.cs
@@ -180,7 +180,7 @@ public sealed class Devices : OrderedKeyedList<Device>
                 device.CategoryId = cmd.CategoryId;
                 device.SubCategory = cmd.Subcategory;
                 device.Revision = cmd.FirmwareRevision;
-                device.IsProductDataRead = true;
+                device.IsProductDataKnown = true;
             }
 
             device.EnsureChannels();

--- a/UnitTestApp/Insteon/TestModelChanges.cs
+++ b/UnitTestApp/Insteon/TestModelChanges.cs
@@ -397,7 +397,7 @@ public class TestModelChanges : ModelTestsBase
             // Simulate acquiring Product Data from the physical device
             device.CategoryId = deviceSpec.CategoryId;
             device.SubCategory = deviceSpec.SubCategory;
-            device.IsProductDataRead = true;
+            device.IsProductDataKnown = true;
             device.DisplayName = deviceSpec.DisplayName;
         }
 

--- a/ViewModel/Devices/ChannelViewModel.cs
+++ b/ViewModel/Devices/ChannelViewModel.cs
@@ -63,7 +63,8 @@ public sealed class ChannelViewModel : BaseViewModel, IChannelObserver
                         delay: new TimeSpan(0, 0, 10),
                         forceSync: false);
                 }
-            });
+            },
+            force: true);
         }
         else if (readCurrentChannelPropertiesJob != null)
         {

--- a/ViewModel/Devices/DeviceViewModel.cs
+++ b/ViewModel/Devices/DeviceViewModel.cs
@@ -185,7 +185,7 @@ public class DeviceViewModel : LinkHostViewModel, IDeviceObserver, IRoomsObserve
             Device.House.Rooms.AddObserver(this);
 
             // Read interesting info from the device
-            // Only attempt to read information from the device if it is connected
+            // but only attempt it if the device is connected
             Device.ScheduleGetConnectionStatus(status => 
             {
                 if (status == Device.ConnectionStatus.Connected )
@@ -203,7 +203,8 @@ public class DeviceViewModel : LinkHostViewModel, IDeviceObserver, IRoomsObserve
                         delay: new TimeSpan(0, 0, 5),
                         forceSync: false);
                 }
-            });
+            }, 
+            force: true);
         }
         else
         {


### PR DESCRIPTION
A set of name changes, cleanups and small enhancements:
- Added "Async" to `TryReadchannelProperties` and `TryWriteChannelProperties` for naming consistency
- Renamed `IsProductDataRead` to `IsProductDataKnown` since this is set by deserializing as well as by reading product data from the device
- Made `force` attribute work on `GetConnectionStatus` and `ScheduleGetConnectionStatus`. This allows to re-ping the device even if we had pinged before, which is now the case when navigating to the device view.
- Introduced Device level methods for reading/writing the properties of a given channel to be able to check on connection status, and for consistency with similar methods. 
- Simplified `ScheduleSync` by utilizing `DeviceNeedsSync` to bail out immediately if no sync is needed. 
- Conditioned Read/Write methods on device being "reachable", i.e., connected and hub operational. 
- Clarified some commentary
