### PR TITLE
Fixed a bug introduced by PR #90

### DIFF
--- a/Insteon/Model/Device.cs
+++ b/Insteon/Model/Device.cs
@@ -1238,7 +1238,6 @@ public sealed class Device : DeviceBase
                     },
                     maxRunCount: 1);
             }
-            return ConnectionStatus.Unknown;
         }
         return Status;
     }


### PR DESCRIPTION
PR #90 erroneously introduced a change where `ScheduleGetConnectionStatus` would return unknown instead of the current value when the connection status was believed to be known. As a result, the header in the Device view would always show "Checking status" instead of the current status.