### PR TITLE
Request to re-acquire connectivity status at the end of each read/write to a device

### DIFF
--- a/Insteon/Model/Channel.cs
+++ b/Insteon/Model/Channel.cs
@@ -459,6 +459,7 @@ public sealed class Channel : ChannelBase
             }
         }
 
+        Device.OnTryReadWriteComplete(success);
         return success;
     }
 
@@ -537,6 +538,7 @@ public sealed class Channel : ChannelBase
         // Reflect writing properties in the sync status
         UpdatePropertiesSyncStatus();
 
+        Device.OnTryReadWriteComplete(success);
         return success;
     }
 }


### PR DESCRIPTION
After attempting to read or write from/to a device, request to re-acquire the connectivity status of the device if the read or write operation failed. This will force a ping of the device to acquire the connectivity status on the next read or write operation and prevent future read/write operations with that device until the device is reconnected.

This change also improves computing the sync status of a device database after reading or writing the database.