### PR TITLE
Cleaned up and simplified the XAML code showing the device connection status

### DIFF
--- a/UnoApp/Views/Devices/DeviceStatusView.xaml
+++ b/UnoApp/Views/Devices/DeviceStatusView.xaml
@@ -1,16 +1,17 @@
-﻿<!-- Copyright 2022 Christian Fortini
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+﻿<!--
+    Copyright 2022 Christian Fortini
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 -->
 
 <ContentControl
@@ -29,8 +30,7 @@
     <ContentControl.ContentTemplate>
         <DataTemplate x:DataType="vm:DeviceViewModel">
             <StackPanel>
-                <!-- We can't use x:Load here or the button bindings won't work (Uno Bug?) -->
-                <StackPanel x:Name="DeviceStatusConnectedView" Visibility="{x:Bind IsConnected, Mode=OneWay}">
+                <StackPanel x:Name="DeviceStatusConnectedView" x:Load="{x:Bind IsConnected, Mode=OneWay}">
                     <Border
                         Background="{StaticResource DeviceStampColor}"
                         CornerRadius="10"
@@ -47,43 +47,28 @@
                     </Border>
                 </StackPanel>
 
-                <StackPanel
-                    Margin="0,6,0,20"
-                    x:Name="DevceStatusDisconnectedView"
-                    x:Load="{x:Bind IsDisconnected, Mode=OneWay}"
-                    Visibility="{x:Bind IsDisconnected, Mode=OneWay}">
+                <StackPanel x:Name="DevceStatusDisconnectedView" x:Load="{x:Bind IsDisconnected, Mode=OneWay}" Margin="0,6,0,20">
                     <TextBlock Margin="0,0,0,6" FontWeight="Bold">Device not connected!</TextBlock>
                     <TextBlock Margin="0,0,0,6">This device is not connected to the Hub!</TextBlock>
                     <Button x:Name="ConnectDeviceButton" Click="{x:Bind ConnectDevice_Click}">Connect Device</Button>
                 </StackPanel>
 
-                <!-- We can't use x:Load here or the button bindings won't work (Uno Bug?) -->
-                <Grid x:Name="DeviceStatusGatewayError" Visibility="{x:Bind IsGatewayError, Mode=OneWay}" Margin="0,0,20,0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    <StackPanel
-                        Grid.Row="1"
-                        Orientation="Vertical"
-                        HorizontalAlignment="Center"
-                        Margin="0,10,0,30"
-                        Background="LightSalmon"
-                        Padding="10">
-                        <TextBlock Margin="0,0,0,6" FontWeight="Bold" TextWrapping="Wrap">We could not contact the Insteon Gateway (Hub).</TextBlock>
-                        <TextBlock Margin="0,0,0,10" TextWrapping="Wrap">
-                            It is either not on the local network or not configured properly.
-                            Go to "Settings" to enter the configuration information.
-                        </TextBlock>
-                        <Button x:Name="DeviceConnectionStatusButton" Click="{x:Bind ForceCheckDeviceConnectionStatus_Click}">Retry</Button>
-                    </StackPanel>
-                </Grid>
-
                 <StackPanel
-                    Orientation="Horizontal"
-                    x:Name="DeviceStatusPending"
-                    x:Load="{x:Bind IsStatusPending, Mode=OneWay}"
-                    Visibility="{x:Bind IsStatusPending, Mode=OneWay}">
+                    x:Name="DeviceStatusGatewayErrorView"
+                    x:Load="{x:Bind IsGatewayError, Mode=OneWay}"
+                    Margin="0,6,0,20"
+                    Background="LightSalmon"
+                    Padding="10">
+                    <TextBlock Margin="0,0,0,6" FontWeight="Bold" TextWrapping="Wrap">We could not contact the Insteon Gateway (Hub).</TextBlock>
+                    <TextBlock Margin="0,0,0,10" TextWrapping="Wrap">
+                        It is either not on the local network or not configured properly.
+                        Go to "Settings" to enter the configuration information.
+                    </TextBlock>
+                    <Button x:Name="DeviceConnectionStatusButton" Click="{x:Bind ForceCheckDeviceConnectionStatus_Click}">Retry</Button>
+                </StackPanel>
+
+
+                <StackPanel Orientation="Horizontal" x:Name="DeviceStatusPendingView" x:Load="{x:Bind IsStatusPending, Mode=OneWay}">
                     <TextBlock Margin="0,6,0,20">Checking device connection status...</TextBlock>
                 </StackPanel>
 


### PR DESCRIPTION
Remove the unnecessary use of a grid and now using only x:Load to determine which content to show, based on the connection status. 