### PR TITLE
More efficient handling of device Connection Status

### DIFF
--- a/Insteon/Model/Devices.cs
+++ b/Insteon/Model/Devices.cs
@@ -678,7 +678,7 @@ public sealed class Devices : OrderedKeyedList<Device>
         userActionContext.device = device;
         userActionContext.handler = handler;
 
-        device.ScheduleGetConnectionStatus((connectionStatus) =>
+        device.ScheduleRetrieveConnectionStatus((connectionStatus) =>
         {
             if (connectionStatus == Device.ConnectionStatus.Connected)
             {
@@ -1044,7 +1044,7 @@ public sealed class Devices : OrderedKeyedList<Device>
             }
             else
             {
-                connected = await device.GetConnectionStatusAsync() == Device.ConnectionStatus.Connected;
+                connected = await device.RetrieveConnectionStatusAsync() == Device.ConnectionStatus.Connected;
             }
 
             if (!connected)

--- a/ViewModel/Devices/ChannelViewModel.cs
+++ b/ViewModel/Devices/ChannelViewModel.cs
@@ -51,7 +51,7 @@ public sealed class ChannelViewModel : BaseViewModel, IChannelObserver
         if (isActive && channel != null)
         {
             // Only attempt to read information from the device if it is connected
-            deviceViewModel.Device.ScheduleGetConnectionStatus(status =>
+            deviceViewModel.Device.ScheduleRetrieveConnectionStatus(status =>
             {
                 if (status == Device.ConnectionStatus.Connected)
                 {

--- a/ViewModel/Devices/DeviceViewModel.cs
+++ b/ViewModel/Devices/DeviceViewModel.cs
@@ -186,7 +186,7 @@ public class DeviceViewModel : LinkHostViewModel, IDeviceObserver, IRoomsObserve
 
             // Read interesting info from the device
             // but only attempt it if the device is connected
-            Device.ScheduleGetConnectionStatus(status => 
+            Device.ScheduleRetrieveConnectionStatus(status => 
             {
                 if (status == Device.ConnectionStatus.Connected )
                 {
@@ -638,7 +638,7 @@ public class DeviceViewModel : LinkHostViewModel, IDeviceObserver, IRoomsObserve
     /// Returns whether this device is connected so that we can send commands to it via the Hub.
     /// The callback is called when the connection status changes.
     /// </summary>
-    public Device.ConnectionStatus DeviceConnectionStatus => Device.ScheduleGetConnectionStatus();
+    public Device.ConnectionStatus DeviceConnectionStatus => Device.ScheduleRetrieveConnectionStatus();
     public bool IsStatusPending => DeviceConnectionStatus == Device.ConnectionStatus.Unknown;
     public bool IsConnected => DeviceConnectionStatus == Device.ConnectionStatus.Connected;
     public bool IsDisconnected => DeviceConnectionStatus == Device.ConnectionStatus.Disconnected;
@@ -970,7 +970,7 @@ public class DeviceViewModel : LinkHostViewModel, IDeviceObserver, IRoomsObserve
     /// <param name="e"></param>
     public void ForceCheckDeviceConnectionStatus_Click(object sender, RoutedEventArgs e)
     {
-        Device.ScheduleGetConnectionStatus(force: true);
+        Device.ScheduleRetrieveConnectionStatus(force: true);
     }
 
     /// <summary>


### PR DESCRIPTION
We now have the following flow for the Connection Status of a device:

`RetrieveConnectionStatusAsync` (renamed form `GetConnectionStatusAsync`) retrieves the connection status by pinging the device if the connection status is not believed to be up to date. It sets the result in `Device.Status` and also sets `isConnectionStatusKnown` to indicate Status is believed to be up to date.

This method is called before attempting any other read/write operation with the device. If the result is not `Connected` the operation and subsequent ones to the same device are prevented, saving useless attempts at interacting with the device. 

Once the problem is believed to be fixed, the user should go to the view for the device, which should retrieve the connection status again. If this doesn't happen automatically, the user can press the "Connect Device" button. 

Any time a read or write operation fails, `isConnectionStatusKnown` is reset to force a new retrieval. If that determines that the device is indeed not connected, no subsequent operations to the same device will be attempted. 

Also renamed `ScheduleGetConnectionStatus` to `ScheduleRetrieveConnectionStatus` for consistency.