### PR TITLE
Repaired unit-tests broken by PR #94 

### DIFF
--- a/UnitTestApp/Insteon/ModelTestsBase.cs
+++ b/UnitTestApp/Insteon/ModelTestsBase.cs
@@ -116,6 +116,10 @@ public static class HouseExtensions
         await house.Devices.AddOrConnectDeviceAsync(newDeviceId);
         var device = house.Devices.GetDeviceByID(newDeviceId)!;
         if (name != null) device.DisplayName = name;
+
+        // TODO: This should do a full sync instead of just reading the new device and the Hub
+        // and leaving the rest of the devices in the house unsynced
+        // But that would require having an async version of ScheduleSyncDevices
         await device.TryReadDevicePropertiesAsync(forceSync: true);
         await device.TryReadAllLinkDatabaseAsync();
         await house.Hub.TryReadAllLinkDatabaseAsync();

--- a/UnitTestApp/Models/Changes/Changes1.xml
+++ b/UnitTestApp/Models/Changes/Changes1.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -516,7 +516,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -694,7 +694,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -755,7 +755,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -945,7 +945,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1201,7 +1201,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1368,7 +1368,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1402,7 +1402,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1419,7 +1419,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1471,7 +1471,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1581,7 +1581,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1615,7 +1615,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1632,7 +1632,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1684,7 +1684,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1778,7 +1778,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1833,7 +1833,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1891,7 +1891,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1949,7 +1949,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1992,7 +1992,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2033,7 +2033,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2050,7 +2050,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2067,7 +2067,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2170,7 +2170,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2328,7 +2328,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2465,7 +2465,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2640,7 +2640,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2689,7 +2689,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2741,7 +2741,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2803,7 +2803,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2940,7 +2940,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3118,7 +3118,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3167,7 +3167,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3213,7 +3213,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />

--- a/UnitTestApp/Refs/Changes/TestAddDevice.xml
+++ b/UnitTestApp/Refs/Changes/TestAddDevice.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:45 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -368,7 +368,7 @@
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="0" data3="4" scene="12" syncstatus="synced" uid="737273190" />
           </record>
           <record sequence="32">
-            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="552723901" />
+            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="2366010438" />
           </record>
         </database>
         <properties lastStatus="Synchronized">
@@ -519,7 +519,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -697,7 +697,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -758,7 +758,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -948,7 +948,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1204,7 +1204,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1371,7 +1371,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1405,7 +1405,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1422,7 +1422,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1474,7 +1474,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1584,7 +1584,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1618,7 +1618,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1635,7 +1635,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1687,7 +1687,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1781,7 +1781,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:45 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1836,7 +1836,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1894,7 +1894,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1952,7 +1952,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1995,7 +1995,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2036,7 +2036,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2053,7 +2053,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2070,7 +2070,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2173,7 +2173,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2331,7 +2331,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2468,7 +2468,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2643,7 +2643,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2692,7 +2692,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2744,7 +2744,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2806,7 +2806,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2943,7 +2943,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3121,7 +3121,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:45 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3170,7 +3170,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:45 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3216,7 +3216,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:45 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />
@@ -3271,15 +3271,15 @@
         </properties>
       </device>
       <device insteonID="11.22.33" category="1" subcategory="1" revision="63" engineVersion="2" status="connected" powerline="1" radio="1" hopIfModSyncFails="0" ipk="00.00.00" wattage="0" webDeviceID="0" webGatewayControllerGroup="0" driver="" displayName="" active="1">
-        <notes added="1/9/2025 3:47:38 PM" />
+        <notes added="5/21/2025 12:11:45 PM" />
         <location />
         <channels />
-        <database sequence="0" lastUpdate="1/1/0001 12:00:00 AM" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:45 PM" lastStatus="Synchronized" revision="0">
           <record sequence="0">
-            <device address="AA.00.00" group="0" recordControl="162" data1="255" data2="28" data3="1" scene="0" syncstatus="synced" uid="3147461433" />
+            <device address="AA.00.00" group="0" recordControl="162" data1="255" data2="28" data3="1" scene="0" syncstatus="synced" uid="3817534251" />
           </record>
           <record sequence="1">
-            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="359475159" />
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="3552902778" />
           </record>
         </database>
         <properties lastStatus="Synchronized" />

--- a/UnitTestApp/Refs/Changes/TestAddDeviceWithChannels.xml
+++ b/UnitTestApp/Refs/Changes/TestAddDeviceWithChannels.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:45 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -368,7 +368,7 @@
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="0" data3="4" scene="12" syncstatus="synced" uid="737273190" />
           </record>
           <record sequence="32">
-            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="1753325904" />
+            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="2495630936" />
           </record>
         </database>
         <properties lastStatus="Synchronized">
@@ -519,7 +519,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -697,7 +697,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -758,7 +758,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -948,7 +948,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1204,7 +1204,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1371,7 +1371,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1405,7 +1405,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1422,7 +1422,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1474,7 +1474,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1584,7 +1584,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1618,7 +1618,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1635,7 +1635,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1687,7 +1687,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1781,7 +1781,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:45 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1836,7 +1836,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1894,7 +1894,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1952,7 +1952,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1995,7 +1995,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2036,7 +2036,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2053,7 +2053,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2070,7 +2070,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2173,7 +2173,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2331,7 +2331,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2468,7 +2468,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2643,7 +2643,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2692,7 +2692,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2744,7 +2744,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2806,7 +2806,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2943,7 +2943,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3121,7 +3121,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:45 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3170,7 +3170,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:45 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3216,7 +3216,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:45 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />
@@ -3271,7 +3271,7 @@
         </properties>
       </device>
       <device insteonID="11.22.33" category="1" subcategory="65" revision="72" engineVersion="2" status="connected" powerline="1" radio="1" hopIfModSyncFails="0" ipk="00.00.00" wattage="0" webDeviceID="0" webGatewayControllerGroup="0" driver="" displayName="" active="1">
-        <notes added="1/9/2025 3:47:39 PM" />
+        <notes added="5/21/2025 12:11:45 PM" />
         <location />
         <channels>
           <channel id="1" />
@@ -3283,17 +3283,17 @@
           <channel id="7" />
           <channel id="8" />
         </channels>
-        <database sequence="0" lastUpdate="1/1/0001 12:00:00 AM" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:45 PM" lastStatus="Synchronized" revision="0">
           <record sequence="0">
-            <device address="AA.00.00" group="0" recordControl="162" data1="255" data2="28" data3="1" scene="0" syncstatus="synced" uid="1759094120" />
+            <device address="AA.00.00" group="0" recordControl="162" data1="255" data2="28" data3="1" scene="0" syncstatus="synced" uid="1410585454" />
           </record>
           <record sequence="1">
-            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="355511217" />
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="3400251755" />
           </record>
         </database>
         <properties lastStatus="Synchronized">
           <p name="operatingFlags">
-            <device value="0x08" lastUpdate="1/9/2025 3:47:39 PM" />
+            <device value="0x08" lastUpdate="5/21/2025 12:11:45 PM" />
           </p>
         </properties>
       </device>

--- a/UnitTestApp/Refs/Changes/TestAddDuplicateRecordToDatabase.xml
+++ b/UnitTestApp/Refs/Changes/TestAddDuplicateRecordToDatabase.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -516,7 +516,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -694,7 +694,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -758,7 +758,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -948,7 +948,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1210,7 +1210,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1377,7 +1377,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1411,7 +1411,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1428,7 +1428,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1480,7 +1480,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1590,7 +1590,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1624,7 +1624,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1641,7 +1641,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1693,7 +1693,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1787,7 +1787,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1842,7 +1842,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1900,7 +1900,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1958,7 +1958,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -2001,7 +2001,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2042,7 +2042,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2059,7 +2059,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2076,7 +2076,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2179,7 +2179,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2337,7 +2337,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2474,7 +2474,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2649,7 +2649,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2698,7 +2698,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2750,7 +2750,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2812,7 +2812,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2949,7 +2949,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3127,7 +3127,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:46 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3176,7 +3176,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3222,7 +3222,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />

--- a/UnitTestApp/Refs/Changes/TestAddScene.xml
+++ b/UnitTestApp/Refs/Changes/TestAddScene.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -516,7 +516,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -663,22 +663,22 @@
             <device address="AA.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="19" syncstatus="synced" uid="3440574630" />
           </record>
           <record sequence="48">
-            <device address="AA.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="1386446346" />
+            <device address="AA.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="4064602042" />
           </record>
           <record sequence="49">
-            <device address="AA.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="3674990633" />
+            <device address="AA.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="2986993861" />
           </record>
           <record sequence="50">
-            <device address="AA.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="573527234" />
+            <device address="AA.44.44" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="1855179781" />
           </record>
           <record sequence="51">
-            <device address="AA.44.44" group="2" recordControl="162" data1="128" data2="28" data3="2" scene="21" syncstatus="changed" uid="1307034959" />
+            <device address="AA.44.44" group="2" recordControl="162" data1="128" data2="28" data3="2" scene="21" syncstatus="changed" uid="4147250945" />
           </record>
           <record sequence="52">
-            <device address="AA.55.55" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="616403615" />
+            <device address="AA.55.55" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="516452767" />
           </record>
           <record sequence="53">
-            <device address="AA.66.66" group="3" recordControl="162" data1="128" data2="28" data3="2" scene="21" syncstatus="changed" uid="1156953097" />
+            <device address="AA.66.66" group="3" recordControl="162" data1="128" data2="28" data3="2" scene="21" syncstatus="changed" uid="1286342165" />
           </record>
           <record sequence="54">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="3289316870" />
@@ -712,7 +712,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -739,13 +739,13 @@
             <device address="AA.11.11" group="3" recordControl="162" data1="51" data2="28" data3="1" scene="19" syncstatus="synced" uid="2966552342" />
           </record>
           <record sequence="8">
-            <device address="AA.11.11" group="2" recordControl="162" data1="36" data2="28" data3="1" scene="21" syncstatus="changed" uid="17484041" />
+            <device address="AA.11.11" group="2" recordControl="162" data1="36" data2="28" data3="1" scene="21" syncstatus="changed" uid="2856010655" />
           </record>
           <record sequence="9">
-            <device address="AA.44.44" group="2" recordControl="162" data1="36" data2="28" data3="1" scene="21" syncstatus="changed" uid="426238759" />
+            <device address="AA.44.44" group="2" recordControl="162" data1="36" data2="28" data3="1" scene="21" syncstatus="changed" uid="1055714079" />
           </record>
           <record sequence="10">
-            <device address="AA.66.66" group="3" recordControl="162" data1="36" data2="28" data3="1" scene="21" syncstatus="changed" uid="1174270818" />
+            <device address="AA.66.66" group="3" recordControl="162" data1="36" data2="28" data3="1" scene="21" syncstatus="changed" uid="3753537211" />
           </record>
           <record sequence="11">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="459744039" />
@@ -782,7 +782,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -803,13 +803,13 @@
             <device address="AA.11.11" group="4" recordControl="162" data1="76" data2="28" data3="1" scene="16" syncstatus="synced" uid="3024636706" />
           </record>
           <record sequence="6">
-            <device address="AA.11.11" group="2" recordControl="162" data1="75" data2="28" data3="1" scene="21" syncstatus="changed" uid="702950805" />
+            <device address="AA.11.11" group="2" recordControl="162" data1="75" data2="28" data3="1" scene="21" syncstatus="changed" uid="1939101997" />
           </record>
           <record sequence="7">
-            <device address="AA.44.44" group="2" recordControl="162" data1="75" data2="28" data3="1" scene="21" syncstatus="changed" uid="1100531639" />
+            <device address="AA.44.44" group="2" recordControl="162" data1="75" data2="28" data3="1" scene="21" syncstatus="changed" uid="1330373891" />
           </record>
           <record sequence="8">
-            <device address="AA.66.66" group="3" recordControl="162" data1="75" data2="28" data3="1" scene="21" syncstatus="changed" uid="1057485976" />
+            <device address="AA.66.66" group="3" recordControl="162" data1="75" data2="28" data3="1" scene="21" syncstatus="changed" uid="1596792741" />
           </record>
           <record sequence="9">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="3092448823" />
@@ -981,7 +981,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1071,28 +1071,28 @@
             <device address="AA.AA.AA" group="3" recordControl="162" data1="255" data2="28" data3="6" scene="0" syncstatus="synced" uid="1704579592" />
           </record>
           <record sequence="29">
-            <device address="AA.11.11" group="2" recordControl="162" data1="128" data2="28" data3="2" scene="21" syncstatus="changed" uid="1679161226" />
+            <device address="AA.11.11" group="2" recordControl="162" data1="128" data2="28" data3="2" scene="21" syncstatus="changed" uid="3540902819" />
           </record>
           <record sequence="30">
-            <device address="AA.11.11" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="532811101" />
+            <device address="AA.11.11" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="2182246209" />
           </record>
           <record sequence="31">
-            <device address="AA.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="1426056848" />
+            <device address="AA.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="3417807542" />
           </record>
           <record sequence="32">
-            <device address="AA.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="3639055837" />
+            <device address="AA.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="4170280610" />
           </record>
           <record sequence="33">
-            <device address="AA.11.11" group="2" recordControl="162" data1="0" data2="28" data3="1" scene="21" syncstatus="changed" uid="1225000721" />
+            <device address="AA.11.11" group="2" recordControl="162" data1="0" data2="28" data3="1" scene="21" syncstatus="changed" uid="2737931938" />
           </record>
           <record sequence="34">
-            <device address="AA.55.55" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="2981833611" />
+            <device address="AA.55.55" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="21" syncstatus="changed" uid="2617622581" />
           </record>
           <record sequence="35">
-            <device address="AA.66.66" group="3" recordControl="162" data1="128" data2="28" data3="2" scene="21" syncstatus="changed" uid="765407038" />
+            <device address="AA.66.66" group="3" recordControl="162" data1="128" data2="28" data3="2" scene="21" syncstatus="changed" uid="2106682667" />
           </record>
           <record sequence="36">
-            <device address="AA.66.66" group="3" recordControl="162" data1="0" data2="28" data3="1" scene="21" syncstatus="changed" uid="3594371499" />
+            <device address="AA.66.66" group="3" recordControl="162" data1="0" data2="28" data3="1" scene="21" syncstatus="changed" uid="375458178" />
           </record>
           <record sequence="37">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="347816714" />
@@ -1261,7 +1261,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1428,7 +1428,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1462,7 +1462,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1479,7 +1479,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1531,7 +1531,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1612,13 +1612,13 @@
             <device address="AA.11.11" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="12" syncstatus="synced" uid="479760813" />
           </record>
           <record sequence="26">
-            <device address="AA.11.11" group="2" recordControl="162" data1="0" data2="28" data3="4" scene="21" syncstatus="changed" uid="3093931235" />
+            <device address="AA.11.11" group="2" recordControl="162" data1="0" data2="28" data3="4" scene="21" syncstatus="changed" uid="2360833776" />
           </record>
           <record sequence="27">
-            <device address="AA.44.44" group="2" recordControl="162" data1="0" data2="28" data3="4" scene="21" syncstatus="changed" uid="407469643" />
+            <device address="AA.44.44" group="2" recordControl="162" data1="0" data2="28" data3="4" scene="21" syncstatus="changed" uid="2635589638" />
           </record>
           <record sequence="28">
-            <device address="AA.66.66" group="3" recordControl="162" data1="0" data2="28" data3="4" scene="21" syncstatus="changed" uid="3601703147" />
+            <device address="AA.66.66" group="3" recordControl="162" data1="0" data2="28" data3="4" scene="21" syncstatus="changed" uid="831622441" />
           </record>
           <record sequence="29">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="3854765321" />
@@ -1650,7 +1650,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1684,7 +1684,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1701,7 +1701,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1753,7 +1753,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1816,19 +1816,19 @@
             <device address="AA.11.11" group="6" recordControl="162" data1="255" data2="28" data3="4" scene="12" syncstatus="synced" uid="3162388355" />
           </record>
           <record sequence="20">
-            <device address="AA.11.11" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="21" syncstatus="changed" uid="3364860258" />
+            <device address="AA.11.11" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="21" syncstatus="changed" uid="1598327063" />
           </record>
           <record sequence="21">
-            <device address="AA.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="21" syncstatus="changed" uid="2618433287" />
+            <device address="AA.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="21" syncstatus="changed" uid="2707096760" />
           </record>
           <record sequence="22">
-            <device address="AA.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="21" syncstatus="changed" uid="239527934" />
+            <device address="AA.33.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="21" syncstatus="changed" uid="1331151728" />
           </record>
           <record sequence="23">
-            <device address="AA.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="21" syncstatus="changed" uid="1904538778" />
+            <device address="AA.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="21" syncstatus="changed" uid="3514012385" />
           </record>
           <record sequence="24">
-            <device address="AA.55.55" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="21" syncstatus="changed" uid="3138054781" />
+            <device address="AA.55.55" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="21" syncstatus="changed" uid="1851179958" />
           </record>
           <record sequence="25">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="1735868728" />
@@ -1862,7 +1862,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1917,7 +1917,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1975,7 +1975,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -2033,7 +2033,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -2076,7 +2076,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2117,7 +2117,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2134,7 +2134,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2151,7 +2151,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2254,7 +2254,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2412,7 +2412,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2549,7 +2549,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2724,7 +2724,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2773,7 +2773,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2825,7 +2825,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2887,7 +2887,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -3024,7 +3024,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3202,7 +3202,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:46 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3251,7 +3251,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3297,7 +3297,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />

--- a/UnitTestApp/Refs/Changes/TestChannelPropertyChange.xml
+++ b/UnitTestApp/Refs/Changes/TestChannelPropertyChange.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -516,7 +516,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -694,7 +694,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -755,7 +755,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -945,7 +945,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1201,7 +1201,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1419,7 +1419,7 @@
               <device value="10" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1471,7 +1471,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1581,7 +1581,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1615,7 +1615,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1632,7 +1632,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1684,7 +1684,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1778,7 +1778,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1833,7 +1833,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1891,7 +1891,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1949,7 +1949,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1992,7 +1992,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2033,7 +2033,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2050,7 +2050,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2067,7 +2067,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2170,7 +2170,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2328,7 +2328,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2465,7 +2465,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2640,7 +2640,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2689,7 +2689,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2741,7 +2741,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2803,7 +2803,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2940,7 +2940,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3118,7 +3118,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:46 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3167,7 +3167,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3213,7 +3213,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:46 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />

--- a/UnitTestApp/Refs/Changes/TestCopyDevice.xml
+++ b/UnitTestApp/Refs/Changes/TestCopyDevice.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -368,13 +368,13 @@
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="0" data3="4" scene="12" syncstatus="synced" uid="737273190" />
           </record>
           <record sequence="32">
-            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="2541337946" />
+            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="2168706631" />
           </record>
           <record sequence="33">
-            <device address="11.22.33" group="0" recordControl="227" data1="1" data2="32" data3="65" scene="0" syncstatus="changed" uid="3250610749" />
+            <device address="11.22.33" group="0" recordControl="227" data1="1" data2="32" data3="65" scene="0" syncstatus="changed" uid="434320161" />
           </record>
           <record sequence="34">
-            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="4052430333" />
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="3185247663" />
           </record>
         </database>
         <properties lastStatus="Synchronized">
@@ -525,7 +525,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -703,7 +703,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -764,7 +764,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -954,7 +954,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1210,7 +1210,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1345,13 +1345,13 @@
             <device address="BB.22.22" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="synced" uid="1161150174" />
           </record>
           <record sequence="44">
-            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="2" syncstatus="changed" uid="1995779456" />
+            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="2" syncstatus="changed" uid="3153913449" />
           </record>
           <record sequence="45">
-            <device address="11.22.33" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="18" syncstatus="changed" uid="1105650208" />
+            <device address="11.22.33" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="18" syncstatus="changed" uid="3647406391" />
           </record>
           <record sequence="46">
-            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="17" syncstatus="changed" uid="1336405513" />
+            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="17" syncstatus="changed" uid="3123543271" />
           </record>
           <record sequence="47">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="2798743367" />
@@ -1386,7 +1386,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1420,7 +1420,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1437,7 +1437,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1489,7 +1489,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1599,7 +1599,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1633,7 +1633,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1650,7 +1650,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1702,7 +1702,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1796,7 +1796,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1851,7 +1851,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1909,7 +1909,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1967,7 +1967,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -2010,7 +2010,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2051,7 +2051,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2068,7 +2068,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2085,7 +2085,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2188,7 +2188,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2346,7 +2346,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2483,7 +2483,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2658,7 +2658,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2707,7 +2707,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2759,7 +2759,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2821,7 +2821,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2958,7 +2958,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3136,7 +3136,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:47 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3185,7 +3185,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3231,7 +3231,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />
@@ -3276,16 +3276,16 @@
             <device address="AA.44.44" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="0" uid="3999223805" />
           </record>
           <record sequence="14">
-            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="17" syncstatus="changed" uid="1440911711" />
+            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="17" syncstatus="changed" uid="2760693186" />
           </record>
           <record sequence="15">
-            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="2" syncstatus="changed" uid="374561109" />
+            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="2" syncstatus="changed" uid="1281317011" />
           </record>
           <record sequence="16">
-            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="18" syncstatus="changed" uid="1250661902" />
+            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="18" syncstatus="changed" uid="1750971533" />
           </record>
           <record sequence="17">
-            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="2116846379" />
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="2160959881" />
           </record>
         </database>
         <properties>
@@ -3301,7 +3301,7 @@
         <notes added="11/30/2014 12:36:12 PM" />
         <location value="Lower cabinet right of fireplace" room="Great Room" />
         <channels />
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10" nextRecordToRead="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="10" nextRecordToRead="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="changed" uid="3398566785" />
@@ -3330,19 +3330,19 @@
         </database>
         <properties lastStatus="Synchronized">
           <p name="ledDimming">
-            <device value="0x3F" lastUpdate="1/9/2025 3:47:42 PM" />
+            <device value="0x3F" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="X10House">
-            <device value="0x20" lastUpdate="1/9/2025 3:47:42 PM" />
+            <device value="0x20" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="X10Unit">
-            <device value="0x20" lastUpdate="1/9/2025 3:47:42 PM" />
+            <device value="0x20" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="onLevel">
-            <device value="0xFF" lastUpdate="1/9/2025 3:47:42 PM" />
+            <device value="0xFF" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="rampRate">
-            <device value="0x1C" lastUpdate="1/9/2025 3:47:42 PM" />
+            <device value="0x1C" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
         </properties>
       </device>

--- a/UnitTestApp/Refs/Changes/TestCopyDeviceWithChannels.xml
+++ b/UnitTestApp/Refs/Changes/TestCopyDeviceWithChannels.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -368,13 +368,13 @@
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="0" data3="4" scene="12" syncstatus="synced" uid="737273190" />
           </record>
           <record sequence="32">
-            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="1228560408" />
+            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="1583152666" />
           </record>
           <record sequence="33">
-            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="changed" uid="2390676199" />
+            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="changed" uid="1060644578" />
           </record>
           <record sequence="34">
-            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="892093605" />
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="3392010162" />
           </record>
         </database>
         <properties lastStatus="Synchronized">
@@ -525,7 +525,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -703,7 +703,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -764,7 +764,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -954,7 +954,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1210,7 +1210,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1377,7 +1377,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1411,7 +1411,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1428,7 +1428,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1480,7 +1480,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1590,7 +1590,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1624,7 +1624,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1641,7 +1641,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1693,7 +1693,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1787,7 +1787,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1842,7 +1842,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1900,7 +1900,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1958,7 +1958,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -2001,7 +2001,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2042,7 +2042,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2059,7 +2059,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2076,7 +2076,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2179,7 +2179,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2308,28 +2308,28 @@
             <device address="AA.DD.DD" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="6" syncstatus="synced" uid="1051228555" />
           </record>
           <record sequence="42">
-            <device address="11.22.33" group="7" recordControl="162" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="1597460323" />
+            <device address="11.22.33" group="7" recordControl="162" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="1065884648" />
           </record>
           <record sequence="43">
-            <device address="11.22.33" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="3920195625" />
+            <device address="11.22.33" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="149360484" />
           </record>
           <record sequence="44">
-            <device address="11.22.33" group="1" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="3303380724" />
+            <device address="11.22.33" group="1" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="2410627757" />
           </record>
           <record sequence="45">
-            <device address="11.22.33" group="2" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="2616928518" />
+            <device address="11.22.33" group="2" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="3478798155" />
           </record>
           <record sequence="46">
-            <device address="11.22.33" group="3" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="1617365377" />
+            <device address="11.22.33" group="3" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="3132960002" />
           </record>
           <record sequence="47">
-            <device address="11.22.33" group="4" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="2100999968" />
+            <device address="11.22.33" group="4" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="2973657189" />
           </record>
           <record sequence="48">
-            <device address="11.22.33" group="5" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="1996798389" />
+            <device address="11.22.33" group="5" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="324392530" />
           </record>
           <record sequence="49">
-            <device address="11.22.33" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="6" syncstatus="changed" uid="369239402" />
+            <device address="11.22.33" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="6" syncstatus="changed" uid="3289682303" />
           </record>
           <record sequence="50">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="4036347935" />
@@ -2361,7 +2361,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2498,7 +2498,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2642,82 +2642,82 @@
             <device address="BB.22.22" group="8" recordControl="162" data1="0" data2="28" data3="5" scene="6" syncstatus="synced" uid="3169851464" />
           </record>
           <record sequence="47">
-            <device address="11.22.33" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="1467482056" />
+            <device address="11.22.33" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="1899073660" />
           </record>
           <record sequence="48">
-            <device address="11.22.33" group="7" recordControl="162" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="4067062831" />
+            <device address="11.22.33" group="7" recordControl="162" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="3263302722" />
           </record>
           <record sequence="49">
-            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="5" syncstatus="changed" uid="399308027" />
+            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="5" syncstatus="changed" uid="3800630174" />
           </record>
           <record sequence="50">
-            <device address="11.22.33" group="4" recordControl="162" data1="255" data2="28" data3="4" scene="5" syncstatus="changed" uid="636118103" />
+            <device address="11.22.33" group="4" recordControl="162" data1="255" data2="28" data3="4" scene="5" syncstatus="changed" uid="4253931495" />
           </record>
           <record sequence="51">
-            <device address="11.22.33" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="6" syncstatus="changed" uid="3673442162" />
+            <device address="11.22.33" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="6" syncstatus="changed" uid="2959271278" />
           </record>
           <record sequence="52">
-            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="1" scene="6" syncstatus="changed" uid="1010494905" />
+            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="1" scene="6" syncstatus="changed" uid="1985982090" />
           </record>
           <record sequence="53">
-            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="2" scene="6" syncstatus="changed" uid="3418632744" />
+            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="2" scene="6" syncstatus="changed" uid="3910392200" />
           </record>
           <record sequence="54">
-            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="3" scene="6" syncstatus="changed" uid="678425152" />
+            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="3" scene="6" syncstatus="changed" uid="2232080275" />
           </record>
           <record sequence="55">
-            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="4" scene="6" syncstatus="changed" uid="3338919593" />
+            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="4" scene="6" syncstatus="changed" uid="2658072934" />
           </record>
           <record sequence="56">
-            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="5" scene="6" syncstatus="changed" uid="2341734036" />
+            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="5" scene="6" syncstatus="changed" uid="3283514251" />
           </record>
           <record sequence="57">
-            <device address="11.22.33" group="1" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="3245463929" />
+            <device address="11.22.33" group="1" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="4214545632" />
           </record>
           <record sequence="58">
-            <device address="11.22.33" group="2" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="1598170250" />
+            <device address="11.22.33" group="2" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="1116892865" />
           </record>
           <record sequence="59">
-            <device address="11.22.33" group="3" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="133056866" />
+            <device address="11.22.33" group="3" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="1365345728" />
           </record>
           <record sequence="60">
-            <device address="11.22.33" group="4" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="2631203307" />
+            <device address="11.22.33" group="4" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="3235197610" />
           </record>
           <record sequence="61">
-            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="7" syncstatus="changed" uid="2507928953" />
+            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="7" syncstatus="changed" uid="84505761" />
           </record>
           <record sequence="62">
-            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="7" syncstatus="changed" uid="1410884590" />
+            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="7" syncstatus="changed" uid="1945762914" />
           </record>
           <record sequence="63">
-            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="7" syncstatus="changed" uid="3542787538" />
+            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="7" syncstatus="changed" uid="925111863" />
           </record>
           <record sequence="64">
-            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="7" syncstatus="changed" uid="14140791" />
+            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="7" syncstatus="changed" uid="2090660218" />
           </record>
           <record sequence="65">
-            <device address="11.22.33" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="7" syncstatus="changed" uid="524350963" />
+            <device address="11.22.33" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="7" syncstatus="changed" uid="2538910412" />
           </record>
           <record sequence="66">
-            <device address="11.22.33" group="5" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="41932772" />
+            <device address="11.22.33" group="5" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="830278651" />
           </record>
           <record sequence="67">
-            <device address="11.22.33" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="8" syncstatus="changed" uid="660107835" />
+            <device address="11.22.33" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="8" syncstatus="changed" uid="4093504549" />
           </record>
           <record sequence="68">
-            <device address="11.22.33" group="5" recordControl="162" data1="255" data2="28" data3="5" scene="8" syncstatus="changed" uid="3130357614" />
+            <device address="11.22.33" group="5" recordControl="162" data1="255" data2="28" data3="5" scene="8" syncstatus="changed" uid="2655450740" />
           </record>
           <record sequence="69">
-            <device address="11.22.33" group="5" recordControl="162" data1="255" data2="28" data3="6" scene="8" syncstatus="changed" uid="4011011336" />
+            <device address="11.22.33" group="5" recordControl="162" data1="255" data2="28" data3="6" scene="8" syncstatus="changed" uid="1107845521" />
           </record>
           <record sequence="70">
-            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="10" syncstatus="changed" uid="3817389058" />
+            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="10" syncstatus="changed" uid="3243728586" />
           </record>
           <record sequence="71">
-            <device address="11.22.33" group="2" recordControl="162" data1="255" data2="28" data3="2" scene="10" syncstatus="changed" uid="725478739" />
+            <device address="11.22.33" group="2" recordControl="162" data1="255" data2="28" data3="2" scene="10" syncstatus="changed" uid="2171509414" />
           </record>
           <record sequence="72">
-            <device address="11.22.33" group="2" recordControl="162" data1="255" data2="28" data3="1" scene="10" syncstatus="changed" uid="4291734633" />
+            <device address="11.22.33" group="2" recordControl="162" data1="255" data2="28" data3="1" scene="10" syncstatus="changed" uid="2488616784" />
           </record>
           <record sequence="73">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="2821700960" />
@@ -2751,7 +2751,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2772,7 +2772,7 @@
             <device address="BB.22.22" group="7" recordControl="162" data1="255" data2="28" data3="1" scene="3" syncstatus="synced" uid="378946673" />
           </record>
           <record sequence="6">
-            <device address="11.22.33" group="7" recordControl="162" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="3526783259" />
+            <device address="11.22.33" group="7" recordControl="162" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="1069381714" />
           </record>
           <record sequence="7">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="656500567" />
@@ -2803,7 +2803,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2821,10 +2821,10 @@
             <device address="AA.EE.EE" group="5" recordControl="162" data1="255" data2="0" data3="1" scene="8" syncstatus="synced" uid="3609166357" />
           </record>
           <record sequence="5">
-            <device address="11.22.33" group="6" recordControl="162" data1="255" data2="31" data3="1" scene="0" syncstatus="changed" uid="2707762898" />
+            <device address="11.22.33" group="6" recordControl="162" data1="255" data2="31" data3="1" scene="0" syncstatus="changed" uid="2948799594" />
           </record>
           <record sequence="6">
-            <device address="11.22.33" group="5" recordControl="162" data1="255" data2="0" data3="1" scene="8" syncstatus="changed" uid="559519980" />
+            <device address="11.22.33" group="5" recordControl="162" data1="255" data2="0" data3="1" scene="8" syncstatus="changed" uid="3665251452" />
           </record>
           <record sequence="7">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="3720847707" />
@@ -2861,7 +2861,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2891,13 +2891,13 @@
             <device address="BB.22.22" group="8" recordControl="162" data1="0" data2="28" data3="1" scene="6" syncstatus="synced" uid="89916659" />
           </record>
           <record sequence="9">
-            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="7" syncstatus="changed" uid="3520519546" />
+            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="7" syncstatus="changed" uid="3430528484" />
           </record>
           <record sequence="10">
-            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="1" scene="6" syncstatus="changed" uid="1030077823" />
+            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="1" scene="6" syncstatus="changed" uid="3459517612" />
           </record>
           <record sequence="11">
-            <device address="11.22.33" group="4" recordControl="162" data1="255" data2="28" data3="1" scene="5" syncstatus="changed" uid="1161763144" />
+            <device address="11.22.33" group="4" recordControl="162" data1="255" data2="28" data3="1" scene="5" syncstatus="changed" uid="355173644" />
           </record>
           <record sequence="12">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="2849600888" />
@@ -2932,7 +2932,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -3069,7 +3069,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3213,82 +3213,82 @@
             <device address="BB.22.22" group="8" recordControl="162" data1="0" data2="28" data3="5" scene="6" syncstatus="synced" uid="2215252001" />
           </record>
           <record sequence="47">
-            <device address="11.22.33" group="2" recordControl="162" data1="75" data2="28" data3="1" scene="10" syncstatus="changed" uid="1486554592" />
+            <device address="11.22.33" group="2" recordControl="162" data1="75" data2="28" data3="1" scene="10" syncstatus="changed" uid="723985752" />
           </record>
           <record sequence="48">
-            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="7" syncstatus="changed" uid="2966325309" />
+            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="7" syncstatus="changed" uid="528192026" />
           </record>
           <record sequence="49">
-            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="5" scene="6" syncstatus="changed" uid="4022661521" />
+            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="5" scene="6" syncstatus="changed" uid="79227189" />
           </record>
           <record sequence="50">
-            <device address="11.22.33" group="2" recordControl="162" data1="255" data2="28" data3="2" scene="10" syncstatus="changed" uid="4197478138" />
+            <device address="11.22.33" group="2" recordControl="162" data1="255" data2="28" data3="2" scene="10" syncstatus="changed" uid="3056338163" />
           </record>
           <record sequence="51">
-            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="5" syncstatus="changed" uid="2936904617" />
+            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="5" syncstatus="changed" uid="3383349006" />
           </record>
           <record sequence="52">
-            <device address="11.22.33" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="6" syncstatus="changed" uid="3473247153" />
+            <device address="11.22.33" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="6" syncstatus="changed" uid="2200384021" />
           </record>
           <record sequence="53">
-            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="1" scene="6" syncstatus="changed" uid="1953298304" />
+            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="1" scene="6" syncstatus="changed" uid="2383675767" />
           </record>
           <record sequence="54">
-            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="2" scene="6" syncstatus="changed" uid="1030061543" />
+            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="2" scene="6" syncstatus="changed" uid="3684254568" />
           </record>
           <record sequence="55">
-            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="3" scene="6" syncstatus="changed" uid="1161194998" />
+            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="3" scene="6" syncstatus="changed" uid="2347959136" />
           </record>
           <record sequence="56">
-            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="4" scene="6" syncstatus="changed" uid="918029118" />
+            <device address="11.22.33" group="8" recordControl="162" data1="0" data2="28" data3="4" scene="6" syncstatus="changed" uid="1062865047" />
           </record>
           <record sequence="57">
-            <device address="11.22.33" group="4" recordControl="162" data1="255" data2="28" data3="4" scene="5" syncstatus="changed" uid="3179326459" />
+            <device address="11.22.33" group="4" recordControl="162" data1="255" data2="28" data3="4" scene="5" syncstatus="changed" uid="2937594204" />
           </record>
           <record sequence="58">
-            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="7" syncstatus="changed" uid="3932908908" />
+            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="7" syncstatus="changed" uid="3244880348" />
           </record>
           <record sequence="59">
-            <device address="11.22.33" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="3170656136" />
+            <device address="11.22.33" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="516695750" />
           </record>
           <record sequence="60">
-            <device address="11.22.33" group="1" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="1419572877" />
+            <device address="11.22.33" group="1" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="3923267285" />
           </record>
           <record sequence="61">
-            <device address="11.22.33" group="2" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="1753521671" />
+            <device address="11.22.33" group="2" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="419615173" />
           </record>
           <record sequence="62">
-            <device address="11.22.33" group="3" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="2185321036" />
+            <device address="11.22.33" group="3" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="1579371209" />
           </record>
           <record sequence="63">
-            <device address="11.22.33" group="4" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="4238826173" />
+            <device address="11.22.33" group="4" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="2673231917" />
           </record>
           <record sequence="64">
-            <device address="11.22.33" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="7" syncstatus="changed" uid="4157312931" />
+            <device address="11.22.33" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="7" syncstatus="changed" uid="3368217174" />
           </record>
           <record sequence="65">
-            <device address="11.22.33" group="7" recordControl="162" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="4046899981" />
+            <device address="11.22.33" group="7" recordControl="162" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="3707930181" />
           </record>
           <record sequence="66">
-            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="7" syncstatus="changed" uid="3659713320" />
+            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="7" syncstatus="changed" uid="3661195197" />
           </record>
           <record sequence="67">
-            <device address="11.22.33" group="5" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="3835403769" />
+            <device address="11.22.33" group="5" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="3765383765" />
           </record>
           <record sequence="68">
-            <device address="11.22.33" group="5" recordControl="162" data1="255" data2="28" data3="5" scene="8" syncstatus="changed" uid="1570911750" />
+            <device address="11.22.33" group="5" recordControl="162" data1="255" data2="28" data3="5" scene="8" syncstatus="changed" uid="4222195774" />
           </record>
           <record sequence="69">
-            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="7" syncstatus="changed" uid="313327833" />
+            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="7" syncstatus="changed" uid="468639506" />
           </record>
           <record sequence="70">
-            <device address="11.22.33" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="8" syncstatus="changed" uid="226677329" />
+            <device address="11.22.33" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="8" syncstatus="changed" uid="2321906699" />
           </record>
           <record sequence="71">
-            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="10" syncstatus="changed" uid="1626996410" />
+            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="10" syncstatus="changed" uid="998881772" />
           </record>
           <record sequence="72">
-            <device address="11.22.33" group="5" recordControl="162" data1="255" data2="28" data3="6" scene="8" syncstatus="changed" uid="375526302" />
+            <device address="11.22.33" group="5" recordControl="162" data1="255" data2="28" data3="6" scene="8" syncstatus="changed" uid="1078220652" />
           </record>
           <record sequence="73">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="2077377145" />
@@ -3325,7 +3325,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3352,7 +3352,7 @@
             <device address="BB.11.11" group="1" recordControl="226" data1="3" data2="31" data3="1" scene="0" uid="2954228148" />
           </record>
           <record sequence="8">
-            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="1667772147" />
+            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="1534801478" />
           </record>
           <record sequence="9">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="1422829945" />
@@ -3377,7 +3377,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3404,10 +3404,10 @@
             <device address="BB.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="9" uid="671519058" />
           </record>
           <record sequence="8">
-            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="2953783930" />
+            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="3495900731" />
           </record>
           <record sequence="9">
-            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="551100528" />
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="1591749014" />
           </record>
         </database>
         <properties>
@@ -3429,7 +3429,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />
@@ -3624,7 +3624,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2" nextRecordToRead="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="2" nextRecordToRead="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="changed" uid="2867033475" />
@@ -3768,82 +3768,82 @@
             <device address="BB.22.22" group="8" recordControl="162" data1="0" data2="28" data3="5" scene="6" syncstatus="changed" uid="3169851464" />
           </record>
           <record sequence="47">
-            <device address="AA.BB.BB" group="7" recordControl="162" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="1020618978" />
+            <device address="AA.BB.BB" group="7" recordControl="162" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="306965572" />
           </record>
           <record sequence="48">
-            <device address="AA.BB.BB" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="27801351" />
+            <device address="AA.BB.BB" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="4066487509" />
           </record>
           <record sequence="49">
-            <device address="AA.BB.BB" group="4" recordControl="162" data1="255" data2="28" data3="4" scene="5" syncstatus="changed" uid="1624444248" />
+            <device address="AA.BB.BB" group="4" recordControl="162" data1="255" data2="28" data3="4" scene="5" syncstatus="changed" uid="1095916514" />
           </record>
           <record sequence="50">
-            <device address="AA.BB.BB" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="5" syncstatus="changed" uid="2266649" />
+            <device address="AA.BB.BB" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="5" syncstatus="changed" uid="2710580130" />
           </record>
           <record sequence="51">
-            <device address="AA.BB.BB" group="8" recordControl="162" data1="0" data2="28" data3="1" scene="6" syncstatus="changed" uid="529843045" />
+            <device address="AA.BB.BB" group="8" recordControl="162" data1="0" data2="28" data3="1" scene="6" syncstatus="changed" uid="3224495711" />
           </record>
           <record sequence="52">
-            <device address="AA.BB.BB" group="8" recordControl="162" data1="0" data2="28" data3="2" scene="6" syncstatus="changed" uid="615456254" />
+            <device address="AA.BB.BB" group="8" recordControl="162" data1="0" data2="28" data3="2" scene="6" syncstatus="changed" uid="3397040077" />
           </record>
           <record sequence="53">
-            <device address="AA.BB.BB" group="8" recordControl="162" data1="0" data2="28" data3="3" scene="6" syncstatus="changed" uid="3914329112" />
+            <device address="AA.BB.BB" group="8" recordControl="162" data1="0" data2="28" data3="3" scene="6" syncstatus="changed" uid="2196069819" />
           </record>
           <record sequence="54">
-            <device address="AA.BB.BB" group="8" recordControl="162" data1="0" data2="28" data3="4" scene="6" syncstatus="changed" uid="2898313378" />
+            <device address="AA.BB.BB" group="8" recordControl="162" data1="0" data2="28" data3="4" scene="6" syncstatus="changed" uid="1764820112" />
           </record>
           <record sequence="55">
-            <device address="AA.BB.BB" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="6" syncstatus="changed" uid="3889671915" />
+            <device address="AA.BB.BB" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="6" syncstatus="changed" uid="2558722473" />
           </record>
           <record sequence="56">
-            <device address="AA.BB.BB" group="8" recordControl="162" data1="0" data2="28" data3="5" scene="6" syncstatus="changed" uid="3421833212" />
+            <device address="AA.BB.BB" group="8" recordControl="162" data1="0" data2="28" data3="5" scene="6" syncstatus="changed" uid="1957134699" />
           </record>
           <record sequence="57">
-            <device address="AA.BB.BB" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="7" syncstatus="changed" uid="1787947846" />
+            <device address="AA.BB.BB" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="7" syncstatus="changed" uid="4195350846" />
           </record>
           <record sequence="58">
-            <device address="AA.BB.BB" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="7" syncstatus="changed" uid="2182835755" />
+            <device address="AA.BB.BB" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="7" syncstatus="changed" uid="3625783032" />
           </record>
           <record sequence="59">
-            <device address="AA.BB.BB" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="7" syncstatus="changed" uid="2388158197" />
+            <device address="AA.BB.BB" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="7" syncstatus="changed" uid="3657177905" />
           </record>
           <record sequence="60">
-            <device address="AA.BB.BB" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="7" syncstatus="changed" uid="3917209187" />
+            <device address="AA.BB.BB" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="7" syncstatus="changed" uid="2719524441" />
           </record>
           <record sequence="61">
-            <device address="AA.BB.BB" group="1" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="2140324755" />
+            <device address="AA.BB.BB" group="1" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="2773867037" />
           </record>
           <record sequence="62">
-            <device address="AA.BB.BB" group="2" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="3397390828" />
+            <device address="AA.BB.BB" group="2" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="599248001" />
           </record>
           <record sequence="63">
-            <device address="AA.BB.BB" group="3" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="2254948265" />
+            <device address="AA.BB.BB" group="3" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="3800188947" />
           </record>
           <record sequence="64">
-            <device address="AA.BB.BB" group="4" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="3767086041" />
+            <device address="AA.BB.BB" group="4" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="304594569" />
           </record>
           <record sequence="65">
-            <device address="AA.BB.BB" group="5" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="1648464781" />
+            <device address="AA.BB.BB" group="5" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="changed" uid="519463900" />
           </record>
           <record sequence="66">
-            <device address="AA.BB.BB" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="7" syncstatus="changed" uid="1608678107" />
+            <device address="AA.BB.BB" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="7" syncstatus="changed" uid="4165058897" />
           </record>
           <record sequence="67">
-            <device address="AA.BB.BB" group="5" recordControl="162" data1="255" data2="28" data3="5" scene="8" syncstatus="changed" uid="3042568684" />
+            <device address="AA.BB.BB" group="5" recordControl="162" data1="255" data2="28" data3="5" scene="8" syncstatus="changed" uid="1309957296" />
           </record>
           <record sequence="68">
-            <device address="AA.BB.BB" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="8" syncstatus="changed" uid="1872828307" />
+            <device address="AA.BB.BB" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="8" syncstatus="changed" uid="3496168485" />
           </record>
           <record sequence="69">
-            <device address="AA.BB.BB" group="5" recordControl="162" data1="255" data2="28" data3="6" scene="8" syncstatus="changed" uid="255432889" />
+            <device address="AA.BB.BB" group="5" recordControl="162" data1="255" data2="28" data3="6" scene="8" syncstatus="changed" uid="2352397579" />
           </record>
           <record sequence="70">
-            <device address="AA.BB.BB" group="2" recordControl="162" data1="255" data2="28" data3="2" scene="10" syncstatus="changed" uid="2274832157" />
+            <device address="AA.BB.BB" group="2" recordControl="162" data1="255" data2="28" data3="2" scene="10" syncstatus="changed" uid="2488733824" />
           </record>
           <record sequence="71">
-            <device address="AA.BB.BB" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="10" syncstatus="changed" uid="501990833" />
+            <device address="AA.BB.BB" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="10" syncstatus="changed" uid="2806363085" />
           </record>
           <record sequence="72">
-            <device address="AA.BB.BB" group="2" recordControl="162" data1="255" data2="28" data3="1" scene="10" syncstatus="changed" uid="3790233866" />
+            <device address="AA.BB.BB" group="2" recordControl="162" data1="255" data2="28" data3="1" scene="10" syncstatus="changed" uid="845467414" />
           </record>
           <record sequence="73">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="changed" uid="2821700960" />
@@ -3851,16 +3851,16 @@
         </database>
         <properties lastStatus="Synchronized">
           <p name="operatingFlags">
-            <device value="0x08" lastUpdate="1/9/2025 3:47:42 PM" />
+            <device value="0x08" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="ledDimming">
-            <device value="0x0D" lastUpdate="1/9/2025 3:47:42 PM" />
+            <device value="0x0D" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="X10House">
-            <device value="0x20" lastUpdate="1/9/2025 3:47:42 PM" />
+            <device value="0x20" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="X10Unit">
-            <device value="0x20" lastUpdate="1/9/2025 3:47:42 PM" />
+            <device value="0x20" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
         </properties>
       </device>

--- a/UnitTestApp/Refs/Changes/TestDevicePropertyChange.xml
+++ b/UnitTestApp/Refs/Changes/TestDevicePropertyChange.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -516,7 +516,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -694,7 +694,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -755,7 +755,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -781,10 +781,10 @@
         </database>
         <properties lastStatus="Changed">
           <p name="operatingFlags">
-            <device value="0x04" lastUpdate="1/9/2025 3:47:43 PM" />
+            <device value="0x04" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="ledDimming">
-            <device value="0x80" lastUpdate="1/9/2025 3:47:43 PM" />
+            <device value="0x80" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="X10House">
             <device value="0x20" lastUpdate="10/26/2013 9:26:00 PM" />
@@ -945,7 +945,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1040,10 +1040,10 @@
         </database>
         <properties lastStatus="Changed">
           <p name="operatingFlags">
-            <device value="0x20" lastUpdate="1/9/2025 3:47:43 PM" />
+            <device value="0x20" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="ledDimming">
-            <device value="0x80" lastUpdate="1/9/2025 3:47:43 PM" />
+            <device value="0x80" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="nonToggleMask">
             <device value="0x00" lastUpdate="1/2/2022 2:30:22 PM" />
@@ -1058,10 +1058,10 @@
             <device value="0x20" lastUpdate="1/12/2014 9:33:00 AM" />
           </p>
           <p name="onLevel">
-            <device value="0x80" lastUpdate="1/9/2025 3:47:43 PM" />
+            <device value="0x80" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
           <p name="rampRate">
-            <device value="0x0A" lastUpdate="1/9/2025 3:47:43 PM" />
+            <device value="0x0A" lastUpdate="5/21/2025 12:11:47 PM" />
           </p>
         </properties>
       </device>
@@ -1207,7 +1207,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1374,7 +1374,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1408,7 +1408,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1425,7 +1425,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1477,7 +1477,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1587,7 +1587,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1621,7 +1621,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1638,7 +1638,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1690,7 +1690,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1784,7 +1784,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1839,7 +1839,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1897,7 +1897,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1955,7 +1955,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1998,7 +1998,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2039,7 +2039,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2056,7 +2056,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2073,7 +2073,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2176,7 +2176,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2334,7 +2334,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2471,7 +2471,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2646,7 +2646,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2695,7 +2695,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2747,7 +2747,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2809,7 +2809,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2946,7 +2946,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3124,7 +3124,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:47 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3173,7 +3173,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3219,7 +3219,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:47 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />

--- a/UnitTestApp/Refs/Changes/TestRemoveDevice.xml
+++ b/UnitTestApp/Refs/Changes/TestRemoveDevice.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -302,7 +302,7 @@
             <device address="BB.22.22" group="5" recordControl="226" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="2395236067" />
           </record>
           <record sequence="10">
-            <device address="AA.22.22" group="0" recordControl="114" data1="1" data2="32" data3="65" scene="0" syncstatus="changed" uid="8056038" />
+            <device address="AA.22.22" group="0" recordControl="114" data1="1" data2="32" data3="65" scene="0" syncstatus="changed" uid="3573567911" />
           </record>
           <record sequence="11">
             <device address="AA.33.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="3826037699" />
@@ -516,7 +516,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -546,7 +546,7 @@
             <device address="AA.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="332138396" />
           </record>
           <record sequence="9">
-            <device address="AA.22.22" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="536682348" />
+            <device address="AA.22.22" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="2198618791" />
           </record>
           <record sequence="10">
             <device address="BB.22.22" group="5" recordControl="162" data1="255" data2="28" data3="8" scene="20" syncstatus="synced" uid="3758562214" />
@@ -588,7 +588,7 @@
             <device address="BB.66.66" group="6" recordControl="162" data1="255" data2="28" data3="1" scene="11" syncstatus="synced" uid="3905720454" />
           </record>
           <record sequence="23">
-            <device address="AA.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="16" syncstatus="changed" uid="3169835409" />
+            <device address="AA.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="16" syncstatus="changed" uid="1635060234" />
           </record>
           <record sequence="24">
             <device address="AA.55.55" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="2917300258" />
@@ -660,7 +660,7 @@
             <device address="BB.66.66" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="19" syncstatus="synced" uid="2459986417" />
           </record>
           <record sequence="47">
-            <device address="AA.22.22" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="19" syncstatus="changed" uid="1177287888" />
+            <device address="AA.22.22" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="19" syncstatus="changed" uid="3708764582" />
           </record>
           <record sequence="48">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="3289316870" />
@@ -694,7 +694,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -884,7 +884,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -908,7 +908,7 @@
             <device address="AA.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="2582712742" />
           </record>
           <record sequence="7">
-            <device address="AA.22.22" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="3124896487" />
+            <device address="AA.22.22" group="2" recordControl="98" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="1618914418" />
           </record>
           <record sequence="8">
             <device address="BB.66.66" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="11" syncstatus="synced" uid="278273342" />
@@ -941,7 +941,7 @@
             <device address="AA.33.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="16" syncstatus="synced" uid="4181905433" />
           </record>
           <record sequence="18">
-            <device address="AA.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="16" syncstatus="changed" uid="1606592177" />
+            <device address="AA.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="16" syncstatus="changed" uid="4000008345" />
           </record>
           <record sequence="19">
             <device address="AA.77.77" group="1" recordControl="162" data1="255" data2="28" data3="8" scene="4" syncstatus="synced" uid="3925384481" />
@@ -1140,7 +1140,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1188,7 +1188,7 @@
             <device address="AA.88.88" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="18" syncstatus="synced" uid="1766743764" />
           </record>
           <record sequence="15">
-            <device address="AA.22.22" group="8" recordControl="98" data1="3" data2="28" data3="8" scene="19" syncstatus="changed" uid="3387437483" />
+            <device address="AA.22.22" group="8" recordControl="98" data1="3" data2="28" data3="8" scene="19" syncstatus="changed" uid="2946536299" />
           </record>
           <record sequence="16">
             <device address="BB.22.22" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="synced" uid="3584775242" />
@@ -1307,7 +1307,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1341,7 +1341,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1358,7 +1358,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1410,7 +1410,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1464,7 +1464,7 @@
             <device address="AA.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="925210081" />
           </record>
           <record sequence="17">
-            <device address="AA.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1388763446" />
+            <device address="AA.22.22" group="6" recordControl="98" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="304282751" />
           </record>
           <record sequence="18">
             <device address="AA.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3464026826" />
@@ -1520,7 +1520,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1554,7 +1554,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1571,7 +1571,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1623,7 +1623,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1717,7 +1717,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1772,7 +1772,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1830,7 +1830,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1888,7 +1888,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1931,7 +1931,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -1972,7 +1972,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1989,7 +1989,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2006,7 +2006,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2109,7 +2109,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2267,7 +2267,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2404,7 +2404,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2579,7 +2579,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2628,7 +2628,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2680,7 +2680,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2742,7 +2742,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2879,7 +2879,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3057,7 +3057,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:48 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3106,7 +3106,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3152,7 +3152,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />

--- a/UnitTestApp/Refs/Changes/TestRemoveDuplicateDatabaseRecords.xml
+++ b/UnitTestApp/Refs/Changes/TestRemoveDuplicateDatabaseRecords.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -516,7 +516,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -534,7 +534,7 @@
             <device address="AA.00.00" group="6" recordControl="170" data1="0" data2="28" data3="8" scene="0" syncstatus="synced" uid="705901014" />
           </record>
           <record sequence="5">
-            <device address="BB.66.66" group="7" recordControl="34" data1="255" data2="0" data3="7" scene="4" syncstatus="changed" uid="1118519737" />
+            <device address="BB.66.66" group="7" recordControl="34" data1="255" data2="0" data3="7" scene="4" syncstatus="changed" uid="1749450220" />
           </record>
           <record sequence="6">
             <device address="AA.77.77" group="1" recordControl="162" data1="255" data2="0" data3="7" scene="4" syncstatus="synced" uid="3546277547" />
@@ -573,7 +573,7 @@
             <device address="BB.66.66" group="7" recordControl="226" data1="3" data2="0" data3="7" scene="4" syncstatus="synced" uid="1147374401" />
           </record>
           <record sequence="18">
-            <device address="BB.66.66" group="8" recordControl="98" data1="3" data2="28" data3="8" scene="20" syncstatus="changed" uid="1793073964" />
+            <device address="BB.66.66" group="8" recordControl="98" data1="3" data2="28" data3="8" scene="20" syncstatus="changed" uid="2871118861" />
           </record>
           <record sequence="19">
             <device address="AA.44.44" group="7" recordControl="226" data1="3" data2="0" data3="7" scene="4" syncstatus="synced" uid="45176265" />
@@ -694,7 +694,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -755,7 +755,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -945,7 +945,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1201,7 +1201,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1216,7 +1216,7 @@
             <device address="AA.44.44" group="6" recordControl="162" data1="255" data2="28" data3="6" scene="11" syncstatus="synced" uid="976428886" />
           </record>
           <record sequence="4">
-            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="2988389106" />
+            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="1202678411" />
           </record>
           <record sequence="5">
             <device address="AA.11.11" group="1" recordControl="162" data1="255" data2="28" data3="6" scene="11" syncstatus="synced" uid="3515307682" />
@@ -1252,7 +1252,7 @@
             <device address="AA.22.22" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="19" syncstatus="synced" uid="1725603950" />
           </record>
           <record sequence="16">
-            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="2309713162" />
+            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="2409989484" />
           </record>
           <record sequence="17">
             <device address="AA.AA.AA" group="3" recordControl="162" data1="0" data2="28" data3="3" scene="18" syncstatus="synced" uid="1544114227" />
@@ -1309,7 +1309,7 @@
             <device address="AA.11.11" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="4" syncstatus="synced" uid="3453202698" />
           </record>
           <record sequence="35">
-            <device address="AA.11.11" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="73282513" />
+            <device address="AA.11.11" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="2048327671" />
           </record>
           <record sequence="36">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="synced" uid="1415271273" />
@@ -1318,7 +1318,7 @@
             <device address="AA.44.44" group="5" recordControl="250" data1="3" data2="28" data3="5" scene="0" syncstatus="synced" uid="1328379597" />
           </record>
           <record sequence="38">
-            <device address="BB.22.22" group="5" recordControl="34" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="541118735" />
+            <device address="BB.22.22" group="5" recordControl="34" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="1530723306" />
           </record>
           <record sequence="39">
             <device address="AA.00.00" group="6" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1805094016" />
@@ -1368,7 +1368,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1402,7 +1402,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1419,7 +1419,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1471,7 +1471,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1581,7 +1581,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1615,7 +1615,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1632,7 +1632,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1684,7 +1684,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1778,7 +1778,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1833,7 +1833,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1891,7 +1891,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1949,7 +1949,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1992,7 +1992,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2033,7 +2033,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2050,7 +2050,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2067,7 +2067,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2170,7 +2170,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2328,7 +2328,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2465,7 +2465,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2640,7 +2640,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2689,7 +2689,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2741,7 +2741,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2803,7 +2803,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2940,7 +2940,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3118,7 +3118,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:48 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3167,7 +3167,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3213,7 +3213,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />

--- a/UnitTestApp/Refs/Changes/TestRemoveDuplicateSceneMember.xml
+++ b/UnitTestApp/Refs/Changes/TestRemoveDuplicateSceneMember.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -516,7 +516,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -558,7 +558,7 @@
             <device address="AA.00.00" group="4" recordControl="162" data1="255" data2="28" data3="6" scene="12" syncstatus="synced" uid="1759536095" />
           </record>
           <record sequence="13">
-            <device address="BB.66.66" group="4" recordControl="162" data1="255" data2="28" data3="8" scene="20" syncstatus="changed" uid="2658113378" />
+            <device address="BB.66.66" group="4" recordControl="162" data1="255" data2="28" data3="8" scene="20" syncstatus="changed" uid="518924584" />
           </record>
           <record sequence="14">
             <device address="AA.44.44" group="8" recordControl="162" data1="255" data2="0" data3="7" scene="4" syncstatus="synced" uid="448626210" />
@@ -573,7 +573,7 @@
             <device address="BB.66.66" group="7" recordControl="226" data1="3" data2="0" data3="7" scene="4" syncstatus="synced" uid="1147374401" />
           </record>
           <record sequence="18">
-            <device address="BB.66.66" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="20" syncstatus="changed" uid="1745675355" />
+            <device address="BB.66.66" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="20" syncstatus="changed" uid="373666060" />
           </record>
           <record sequence="19">
             <device address="AA.44.44" group="7" recordControl="226" data1="3" data2="0" data3="7" scene="4" syncstatus="synced" uid="45176265" />
@@ -648,7 +648,7 @@
             <device address="BB.66.66" group="6" recordControl="162" data1="0" data2="28" data3="3" scene="11" syncstatus="synced" uid="1522509858" />
           </record>
           <record sequence="43">
-            <device address="BB.66.66" group="8" recordControl="98" data1="3" data2="28" data3="8" scene="20" syncstatus="changed" uid="3267794118" />
+            <device address="BB.66.66" group="8" recordControl="98" data1="3" data2="28" data3="8" scene="20" syncstatus="changed" uid="2739206644" />
           </record>
           <record sequence="44">
             <device address="BB.66.66" group="8" recordControl="162" data1="255" data2="28" data3="3" scene="19" syncstatus="synced" uid="2039575949" />
@@ -694,7 +694,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -755,7 +755,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -945,7 +945,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1201,7 +1201,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1216,7 +1216,7 @@
             <device address="AA.44.44" group="6" recordControl="162" data1="255" data2="28" data3="6" scene="11" syncstatus="synced" uid="976428886" />
           </record>
           <record sequence="4">
-            <device address="BB.22.22" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="1460574364" />
+            <device address="BB.22.22" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="3444715519" />
           </record>
           <record sequence="5">
             <device address="AA.11.11" group="1" recordControl="162" data1="255" data2="28" data3="6" scene="11" syncstatus="synced" uid="3515307682" />
@@ -1252,7 +1252,7 @@
             <device address="AA.22.22" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="19" syncstatus="synced" uid="1725603950" />
           </record>
           <record sequence="16">
-            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="745685145" />
+            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="1359529221" />
           </record>
           <record sequence="17">
             <device address="AA.AA.AA" group="3" recordControl="162" data1="0" data2="28" data3="3" scene="18" syncstatus="synced" uid="1544114227" />
@@ -1309,16 +1309,16 @@
             <device address="AA.11.11" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="4" syncstatus="synced" uid="3453202698" />
           </record>
           <record sequence="35">
-            <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="1957291757" />
+            <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="329541660" />
           </record>
           <record sequence="36">
-            <device address="AA.11.11" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="3208799816" />
+            <device address="AA.11.11" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="3055868453" />
           </record>
           <record sequence="37">
             <device address="AA.44.44" group="5" recordControl="250" data1="3" data2="28" data3="5" scene="0" syncstatus="synced" uid="1328379597" />
           </record>
           <record sequence="38">
-            <device address="BB.22.22" group="5" recordControl="162" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="1443320029" />
+            <device address="BB.22.22" group="5" recordControl="162" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="2775689544" />
           </record>
           <record sequence="39">
             <device address="AA.00.00" group="6" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1805094016" />
@@ -1327,13 +1327,13 @@
             <device address="AA.11.11" group="7" recordControl="162" data1="255" data2="28" data3="7" scene="4" syncstatus="synced" uid="1530339041" />
           </record>
           <record sequence="41">
-            <device address="AA.11.11" group="8" recordControl="162" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="3786735816" />
+            <device address="AA.11.11" group="8" recordControl="162" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="77319602" />
           </record>
           <record sequence="42">
-            <device address="BB.22.22" group="5" recordControl="34" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="1408331869" />
+            <device address="BB.22.22" group="5" recordControl="34" data1="255" data2="28" data3="4" scene="20" syncstatus="changed" uid="2806382767" />
           </record>
           <record sequence="43">
-            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="897936325" />
+            <device address="BB.22.22" group="4" recordControl="98" data1="3" data2="28" data3="4" scene="20" syncstatus="changed" uid="2446641818" />
           </record>
           <record sequence="44">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="2798743367" />
@@ -1368,7 +1368,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1402,7 +1402,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1419,7 +1419,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1471,7 +1471,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1581,7 +1581,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1615,7 +1615,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1632,7 +1632,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1684,7 +1684,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1778,7 +1778,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1833,7 +1833,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1891,7 +1891,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1949,7 +1949,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1992,7 +1992,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2033,7 +2033,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2050,7 +2050,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2067,7 +2067,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2170,7 +2170,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2230,13 +2230,13 @@
             <device address="AA.BB.BB" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="3" syncstatus="synced" uid="3480740412" />
           </record>
           <record sequence="19">
-            <device address="BB.66.66" group="4" recordControl="162" data1="255" data2="28" data3="5" scene="20" syncstatus="changed" uid="3220942705" />
+            <device address="BB.66.66" group="4" recordControl="162" data1="255" data2="28" data3="5" scene="20" syncstatus="changed" uid="3035329416" />
           </record>
           <record sequence="20">
             <device address="AA.11.11" group="8" recordControl="162" data1="255" data2="28" data3="5" scene="20" syncstatus="synced" uid="3536796012" />
           </record>
           <record sequence="21">
-            <device address="BB.66.66" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="20" syncstatus="changed" uid="3839705833" />
+            <device address="BB.66.66" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="20" syncstatus="changed" uid="2602010738" />
           </record>
           <record sequence="22">
             <device address="AA.11.11" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="20" syncstatus="synced" uid="2134301513" />
@@ -2328,7 +2328,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2465,7 +2465,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2640,7 +2640,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2689,7 +2689,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2741,7 +2741,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2803,7 +2803,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2940,7 +2940,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3118,7 +3118,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:48 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3167,7 +3167,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3213,7 +3213,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:48 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />

--- a/UnitTestApp/Refs/Changes/TestRemoveScene.xml
+++ b/UnitTestApp/Refs/Changes/TestRemoveScene.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -516,7 +516,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -694,7 +694,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -755,7 +755,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -945,7 +945,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1201,7 +1201,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1368,7 +1368,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1402,7 +1402,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1419,7 +1419,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1471,7 +1471,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1581,7 +1581,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1615,7 +1615,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1632,7 +1632,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1684,7 +1684,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1778,7 +1778,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1833,7 +1833,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1891,7 +1891,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1949,7 +1949,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1992,7 +1992,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2033,7 +2033,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2050,7 +2050,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2067,7 +2067,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2170,7 +2170,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2212,22 +2212,22 @@
             <device address="BB.55.55" group="4" recordControl="162" data1="0" data2="28" data3="2" scene="9" syncstatus="synced" uid="1647200777" />
           </record>
           <record sequence="13">
-            <device address="AA.EE.EE" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="4276814296" />
+            <device address="AA.EE.EE" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="2128527551" />
           </record>
           <record sequence="14">
-            <device address="AA.BB.BB" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="776419880" />
+            <device address="AA.BB.BB" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="3196408546" />
           </record>
           <record sequence="15">
-            <device address="BB.44.44" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="3930790052" />
+            <device address="BB.44.44" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="1950128" />
           </record>
           <record sequence="16">
-            <device address="BB.55.55" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="1417388017" />
+            <device address="BB.55.55" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="174029754" />
           </record>
           <record sequence="17">
-            <device address="AA.EE.EE" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="960930331" />
+            <device address="AA.EE.EE" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="3577545211" />
           </record>
           <record sequence="18">
-            <device address="AA.BB.BB" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="2754093739" />
+            <device address="AA.BB.BB" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="849361324" />
           </record>
           <record sequence="19">
             <device address="BB.66.66" group="4" recordControl="162" data1="255" data2="28" data3="5" scene="20" syncstatus="synced" uid="711620596" />
@@ -2242,7 +2242,7 @@
             <device address="AA.11.11" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="20" syncstatus="synced" uid="2134301513" />
           </record>
           <record sequence="23">
-            <device address="BB.33.33" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="4121819702" />
+            <device address="BB.33.33" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="2018173873" />
           </record>
           <record sequence="24">
             <device address="BB.44.44" group="4" recordControl="162" data1="255" data2="28" data3="8" scene="0" syncstatus="synced" uid="771356921" />
@@ -2328,7 +2328,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2465,7 +2465,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2540,13 +2540,13 @@
             <device address="AA.EE.EE" group="5" recordControl="162" data1="255" data2="28" data3="5" scene="8" syncstatus="synced" uid="717908286" />
           </record>
           <record sequence="24">
-            <device address="BB.44.44" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="917358306" />
+            <device address="BB.44.44" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="198119756" />
           </record>
           <record sequence="25">
             <device address="AA.EE.EE" group="2" recordControl="162" data1="255" data2="28" data3="1" scene="10" syncstatus="synced" uid="3677345566" />
           </record>
           <record sequence="26">
-            <device address="BB.55.55" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="3967439780" />
+            <device address="BB.55.55" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="935796350" />
           </record>
           <record sequence="27">
             <device address="BB.22.22" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="7" syncstatus="synced" uid="2828155116" />
@@ -2555,16 +2555,16 @@
             <device address="AA.EE.EE" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="7" syncstatus="synced" uid="866187947" />
           </record>
           <record sequence="29">
-            <device address="BB.22.22" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="3762564651" />
+            <device address="BB.22.22" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="1381723865" />
           </record>
           <record sequence="30">
-            <device address="BB.33.33" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="3345354558" />
+            <device address="BB.33.33" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="2188656249" />
           </record>
           <record sequence="31">
-            <device address="AA.EE.EE" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="4198996956" />
+            <device address="AA.EE.EE" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="1272708832" />
           </record>
           <record sequence="32">
-            <device address="AA.EE.EE" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="3269475452" />
+            <device address="AA.EE.EE" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="148815036" />
           </record>
           <record sequence="33">
             <device address="BB.22.22" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="7" syncstatus="synced" uid="2077120903" />
@@ -2591,7 +2591,7 @@
             <device address="AA.EE.EE" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="10" syncstatus="synced" uid="1614596607" />
           </record>
           <record sequence="41">
-            <device address="BB.22.22" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="2636826083" />
+            <device address="BB.22.22" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="3377728906" />
           </record>
           <record sequence="42">
             <device address="BB.22.22" group="8" recordControl="162" data1="0" data2="28" data3="1" scene="6" syncstatus="synced" uid="3571855705" />
@@ -2640,25 +2640,25 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
           </record>
           <record sequence="1">
-            <device address="BB.55.55" group="3" recordControl="34" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="2976326976" />
+            <device address="BB.55.55" group="3" recordControl="34" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="1598769019" />
           </record>
           <record sequence="2">
-            <device address="AA.EE.EE" group="7" recordControl="34" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="1065434065" />
+            <device address="AA.EE.EE" group="7" recordControl="34" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="2421562266" />
           </record>
           <record sequence="3">
-            <device address="AA.BB.BB" group="7" recordControl="34" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="2231315675" />
+            <device address="AA.BB.BB" group="7" recordControl="34" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="3578660308" />
           </record>
           <record sequence="4">
-            <device address="BB.44.44" group="3" recordControl="34" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="1390877529" />
+            <device address="BB.44.44" group="3" recordControl="34" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="3224176537" />
           </record>
           <record sequence="5">
-            <device address="BB.22.22" group="7" recordControl="34" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="3786693754" />
+            <device address="BB.22.22" group="7" recordControl="34" data1="255" data2="28" data3="1" scene="3" syncstatus="changed" uid="934749577" />
           </record>
           <record sequence="6">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="656500567" />
@@ -2689,7 +2689,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2741,7 +2741,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2803,7 +2803,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2940,7 +2940,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -2949,7 +2949,7 @@
             <device address="AA.BB.BB" group="2" recordControl="162" data1="75" data2="28" data3="1" scene="10" syncstatus="synced" uid="3915244065" />
           </record>
           <record sequence="2">
-            <device address="BB.55.55" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="3618922441" />
+            <device address="BB.55.55" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="892033970" />
           </record>
           <record sequence="3">
             <device address="AA.BB.BB" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="7" syncstatus="synced" uid="1776077620" />
@@ -2991,7 +2991,7 @@
             <device address="AA.BB.BB" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="7" syncstatus="synced" uid="1941711315" />
           </record>
           <record sequence="16">
-            <device address="AA.BB.BB" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="839607123" />
+            <device address="AA.BB.BB" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="3420466271" />
           </record>
           <record sequence="17">
             <device address="AA.BB.BB" group="1" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="synced" uid="4073111951" />
@@ -3009,16 +3009,16 @@
             <device address="AA.DD.DD" group="1" recordControl="162" data1="0" data2="28" data3="8" scene="7" syncstatus="synced" uid="1422847416" />
           </record>
           <record sequence="22">
-            <device address="BB.33.33" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="890629929" />
+            <device address="BB.33.33" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="1788037640" />
           </record>
           <record sequence="23">
             <device address="AA.BB.BB" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="7" syncstatus="synced" uid="4190722879" />
           </record>
           <record sequence="24">
-            <device address="BB.22.22" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="4200290788" />
+            <device address="BB.22.22" group="7" recordControl="98" data1="3" data2="28" data3="7" scene="3" syncstatus="changed" uid="1748887458" />
           </record>
           <record sequence="25">
-            <device address="AA.BB.BB" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="348048065" />
+            <device address="AA.BB.BB" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="4271380608" />
           </record>
           <record sequence="26">
             <device address="AA.BB.BB" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="7" syncstatus="synced" uid="166067574" />
@@ -3030,7 +3030,7 @@
             <device address="AA.BB.BB" group="5" recordControl="162" data1="255" data2="28" data3="5" scene="8" syncstatus="synced" uid="1587849095" />
           </record>
           <record sequence="29">
-            <device address="BB.44.44" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="2465371231" />
+            <device address="BB.44.44" group="3" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="3774899528" />
           </record>
           <record sequence="30">
             <device address="AA.DD.DD" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="5" syncstatus="synced" uid="3927835393" />
@@ -3066,7 +3066,7 @@
             <device address="AA.BB.BB" group="5" recordControl="162" data1="255" data2="28" data3="6" scene="8" syncstatus="synced" uid="477192055" />
           </record>
           <record sequence="41">
-            <device address="BB.22.22" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="3742000172" />
+            <device address="BB.22.22" group="7" recordControl="34" data1="255" data2="28" data3="7" scene="3" syncstatus="changed" uid="2406475582" />
           </record>
           <record sequence="42">
             <device address="BB.22.22" group="8" recordControl="162" data1="0" data2="28" data3="1" scene="6" syncstatus="synced" uid="1714416930" />
@@ -3118,13 +3118,13 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
-            <device address="BB.22.22" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="228115804" />
+            <device address="BB.22.22" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="3897263262" />
           </record>
           <record sequence="1">
-            <device address="BB.33.33" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="335025867" />
+            <device address="BB.33.33" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="455231042" />
           </record>
           <record sequence="2">
             <device address="AA.FF.FF" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="9" uid="3995387984" />
@@ -3136,10 +3136,10 @@
             <device address="BB.22.22" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="9" uid="9970394" />
           </record>
           <record sequence="5">
-            <device address="AA.EE.EE" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="2066126246" />
+            <device address="AA.EE.EE" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="1222337202" />
           </record>
           <record sequence="6">
-            <device address="AA.BB.BB" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="1163798533" />
+            <device address="AA.BB.BB" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="3820242618" />
           </record>
           <record sequence="7">
             <device address="BB.11.11" group="1" recordControl="226" data1="3" data2="31" data3="1" scene="0" uid="2954228148" />
@@ -3167,19 +3167,19 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
-            <device address="AA.EE.EE" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="723703966" />
+            <device address="AA.EE.EE" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="2339096149" />
           </record>
           <record sequence="1">
-            <device address="AA.BB.BB" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="1642036508" />
+            <device address="AA.BB.BB" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="3769966395" />
           </record>
           <record sequence="2">
-            <device address="BB.33.33" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="4093947744" />
+            <device address="BB.33.33" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="183479528" />
           </record>
           <record sequence="3">
-            <device address="BB.22.22" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="2529274060" />
+            <device address="BB.22.22" group="3" recordControl="98" data1="3" data2="28" data3="3" scene="3" syncstatus="changed" uid="2821895049" />
           </record>
           <record sequence="4">
             <device address="BB.22.22" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="9" uid="1869196509" />
@@ -3213,7 +3213,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />

--- a/UnitTestApp/Refs/Changes/TestReplaceDevice.xml
+++ b/UnitTestApp/Refs/Changes/TestReplaceDevice.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -368,7 +368,7 @@
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="0" data3="4" scene="12" syncstatus="synced" uid="737273190" />
           </record>
           <record sequence="32">
-            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="4136491007" />
+            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="1333859337" />
           </record>
         </database>
         <properties lastStatus="Synchronized">
@@ -519,7 +519,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -549,7 +549,7 @@
             <device address="AA.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="332138396" />
           </record>
           <record sequence="9">
-            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="3060701959" />
+            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="2868078465" />
           </record>
           <record sequence="10">
             <device address="BB.22.22" group="5" recordControl="162" data1="255" data2="28" data3="8" scene="20" syncstatus="synced" uid="3758562214" />
@@ -591,7 +591,7 @@
             <device address="BB.66.66" group="6" recordControl="162" data1="255" data2="28" data3="1" scene="11" syncstatus="synced" uid="3905720454" />
           </record>
           <record sequence="23">
-            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="16" syncstatus="changed" uid="2908997738" />
+            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="16" syncstatus="changed" uid="4274070051" />
           </record>
           <record sequence="24">
             <device address="AA.55.55" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="2917300258" />
@@ -663,7 +663,7 @@
             <device address="BB.66.66" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="19" syncstatus="synced" uid="2459986417" />
           </record>
           <record sequence="47">
-            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="19" syncstatus="changed" uid="1313507912" />
+            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="19" syncstatus="changed" uid="815957196" />
           </record>
           <record sequence="48">
             <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="3289316870" />
@@ -697,7 +697,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="0" lastUpdate="1/9/2025 3:47:46 PM" lastStatus="Changed" revision="0" nextRecordToRead="0" />
+        <database sequence="0" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="0" nextRecordToRead="0" />
         <properties lastStatus="Synchronized">
           <p name="operatingFlags">
             <device value="0x00" lastUpdate="10/26/2013 9:25:00 PM" />
@@ -729,7 +729,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -919,7 +919,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -943,7 +943,7 @@
             <device address="AA.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="2582712742" />
           </record>
           <record sequence="7">
-            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="343015292" />
+            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="2518774746" />
           </record>
           <record sequence="8">
             <device address="BB.66.66" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="11" syncstatus="synced" uid="278273342" />
@@ -976,7 +976,7 @@
             <device address="AA.33.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="16" syncstatus="synced" uid="4181905433" />
           </record>
           <record sequence="18">
-            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="16" syncstatus="changed" uid="1720251613" />
+            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="16" syncstatus="changed" uid="2580885705" />
           </record>
           <record sequence="19">
             <device address="AA.77.77" group="1" recordControl="162" data1="255" data2="28" data3="8" scene="4" syncstatus="synced" uid="3925384481" />
@@ -1175,7 +1175,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1223,7 +1223,7 @@
             <device address="AA.88.88" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="18" syncstatus="synced" uid="1766743764" />
           </record>
           <record sequence="15">
-            <device address="11.22.33" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="19" syncstatus="changed" uid="3489379604" />
+            <device address="11.22.33" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="19" syncstatus="changed" uid="3157993568" />
           </record>
           <record sequence="16">
             <device address="BB.22.22" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="synced" uid="3584775242" />
@@ -1342,7 +1342,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1376,7 +1376,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1393,7 +1393,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1445,7 +1445,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1499,7 +1499,7 @@
             <device address="AA.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="925210081" />
           </record>
           <record sequence="17">
-            <device address="11.22.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1210591712" />
+            <device address="11.22.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="361321805" />
           </record>
           <record sequence="18">
             <device address="AA.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3464026826" />
@@ -1555,7 +1555,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1589,7 +1589,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1606,7 +1606,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1658,7 +1658,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1752,7 +1752,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1807,7 +1807,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1865,7 +1865,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1923,7 +1923,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1966,7 +1966,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2007,7 +2007,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2024,7 +2024,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2041,7 +2041,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2144,7 +2144,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2302,7 +2302,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2439,7 +2439,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2614,7 +2614,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2663,7 +2663,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2715,7 +2715,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2777,7 +2777,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2914,7 +2914,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3092,7 +3092,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:49 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3141,7 +3141,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3187,7 +3187,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />
@@ -3245,7 +3245,7 @@
         <notes added="11/30/2014 12:36:04 PM" />
         <location value="Dinning hutch lower cabinet" room="Kitchen" />
         <channels />
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="657642853" />
@@ -3277,19 +3277,19 @@
         </database>
         <properties lastStatus="Synchronized">
           <p name="ledDimming">
-            <device value="0x3F" lastUpdate="1/9/2025 3:47:46 PM" />
+            <device value="0x3F" lastUpdate="5/21/2025 12:11:49 PM" />
           </p>
           <p name="X10House">
-            <device value="0x20" lastUpdate="1/9/2025 3:47:46 PM" />
+            <device value="0x20" lastUpdate="5/21/2025 12:11:49 PM" />
           </p>
           <p name="X10Unit">
-            <device value="0x20" lastUpdate="1/9/2025 3:47:46 PM" />
+            <device value="0x20" lastUpdate="5/21/2025 12:11:49 PM" />
           </p>
           <p name="onLevel">
-            <device value="0xFF" lastUpdate="1/9/2025 3:47:46 PM" />
+            <device value="0xFF" lastUpdate="5/21/2025 12:11:49 PM" />
           </p>
           <p name="rampRate">
-            <device value="0x1C" lastUpdate="1/9/2025 3:47:46 PM" />
+            <device value="0x1C" lastUpdate="5/21/2025 12:11:49 PM" />
           </p>
         </properties>
       </device>

--- a/UnitTestApp/Refs/Changes/TestReplaceDeviceWithChannels.xml
+++ b/UnitTestApp/Refs/Changes/TestReplaceDeviceWithChannels.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -368,7 +368,7 @@
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="0" data3="4" scene="12" syncstatus="synced" uid="737273190" />
           </record>
           <record sequence="32">
-            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="1301953013" />
+            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="3478786684" />
           </record>
         </database>
         <properties lastStatus="Synchronized">
@@ -519,7 +519,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -543,7 +543,7 @@
             <device address="AA.77.77" group="1" recordControl="162" data1="255" data2="0" data3="7" scene="4" syncstatus="synced" uid="3546277547" />
           </record>
           <record sequence="7">
-            <device address="11.22.33" group="4" recordControl="162" data1="0" data2="28" data3="2" scene="16" syncstatus="changed" uid="4229236766" />
+            <device address="11.22.33" group="4" recordControl="162" data1="0" data2="28" data3="2" scene="16" syncstatus="changed" uid="1276167439" />
           </record>
           <record sequence="8">
             <device address="AA.33.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="synced" uid="332138396" />
@@ -564,7 +564,7 @@
             <device address="BB.66.66" group="4" recordControl="162" data1="255" data2="28" data3="8" scene="20" syncstatus="synced" uid="1364335577" />
           </record>
           <record sequence="14">
-            <device address="11.22.33" group="8" recordControl="162" data1="255" data2="0" data3="7" scene="4" syncstatus="changed" uid="3456005154" />
+            <device address="11.22.33" group="8" recordControl="162" data1="255" data2="0" data3="7" scene="4" syncstatus="changed" uid="1255610443" />
           </record>
           <record sequence="15">
             <device address="AA.AA.AA" group="4" recordControl="162" data1="255" data2="0" data3="7" scene="4" syncstatus="synced" uid="317321910" />
@@ -579,13 +579,13 @@
             <device address="BB.66.66" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="20" syncstatus="synced" uid="3255523099" />
           </record>
           <record sequence="19">
-            <device address="11.22.33" group="7" recordControl="226" data1="3" data2="0" data3="7" scene="4" syncstatus="changed" uid="3167293018" />
+            <device address="11.22.33" group="7" recordControl="226" data1="3" data2="0" data3="7" scene="4" syncstatus="changed" uid="2608261825" />
           </record>
           <record sequence="20">
             <device address="AA.55.55" group="1" recordControl="162" data1="255" data2="28" data3="6" scene="12" syncstatus="synced" uid="2089450474" />
           </record>
           <record sequence="21">
-            <device address="11.22.33" group="6" recordControl="162" data1="255" data2="28" data3="1" scene="11" syncstatus="changed" uid="542820454" />
+            <device address="11.22.33" group="6" recordControl="162" data1="255" data2="28" data3="1" scene="11" syncstatus="changed" uid="1099426455" />
           </record>
           <record sequence="22">
             <device address="BB.66.66" group="6" recordControl="162" data1="255" data2="28" data3="1" scene="11" syncstatus="synced" uid="3905720454" />
@@ -600,13 +600,13 @@
             <device address="AA.33.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="16" syncstatus="synced" uid="4276013731" />
           </record>
           <record sequence="26">
-            <device address="11.22.33" group="2" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="1428455297" />
+            <device address="11.22.33" group="2" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="changed" uid="4225609510" />
           </record>
           <record sequence="27">
             <device address="AA.55.55" group="6" recordControl="162" data1="255" data2="28" data3="2" scene="1" syncstatus="synced" uid="3939852784" />
           </record>
           <record sequence="28">
-            <device address="11.22.33" group="4" recordControl="162" data1="255" data2="28" data3="4" scene="16" syncstatus="changed" uid="3648943890" />
+            <device address="11.22.33" group="4" recordControl="162" data1="255" data2="28" data3="4" scene="16" syncstatus="changed" uid="3873742877" />
           </record>
           <record sequence="29">
             <device address="AA.66.66" group="1" recordControl="162" data1="255" data2="28" data3="6" scene="12" syncstatus="synced" uid="2542944728" />
@@ -618,34 +618,34 @@
             <device address="AA.55.55" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="12" syncstatus="synced" uid="4191965317" />
           </record>
           <record sequence="32">
-            <device address="11.22.33" group="6" recordControl="162" data1="255" data2="28" data3="5" scene="11" syncstatus="changed" uid="1103267532" />
+            <device address="11.22.33" group="6" recordControl="162" data1="255" data2="28" data3="5" scene="11" syncstatus="changed" uid="3890280335" />
           </record>
           <record sequence="33">
             <device address="BB.66.66" group="6" recordControl="162" data1="255" data2="28" data3="5" scene="11" syncstatus="synced" uid="3512199666" />
           </record>
           <record sequence="34">
-            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="11" syncstatus="changed" uid="3528632683" />
+            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="11" syncstatus="changed" uid="3257932392" />
           </record>
           <record sequence="35">
             <device address="AA.66.66" group="6" recordControl="234" data1="3" data2="28" data3="6" scene="12" syncstatus="synced" uid="1554502591" />
           </record>
           <record sequence="36">
-            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="2434605662" />
+            <device address="11.22.33" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="1" syncstatus="changed" uid="2111670162" />
           </record>
           <record sequence="37">
-            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="16" syncstatus="changed" uid="1375298789" />
+            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="16" syncstatus="changed" uid="1573171504" />
           </record>
           <record sequence="38">
             <device address="BB.66.66" group="8" recordControl="162" data1="255" data2="28" data3="5" scene="19" syncstatus="synced" uid="3677082040" />
           </record>
           <record sequence="39">
-            <device address="11.22.33" group="2" recordControl="162" data1="0" data2="28" data3="4" scene="1" syncstatus="changed" uid="1499429765" />
+            <device address="11.22.33" group="2" recordControl="162" data1="0" data2="28" data3="4" scene="1" syncstatus="changed" uid="895779799" />
           </record>
           <record sequence="40">
             <device address="AA.55.55" group="6" recordControl="162" data1="0" data2="28" data3="4" scene="1" syncstatus="synced" uid="2937758226" />
           </record>
           <record sequence="41">
-            <device address="11.22.33" group="6" recordControl="162" data1="0" data2="28" data3="3" scene="11" syncstatus="changed" uid="229569461" />
+            <device address="11.22.33" group="6" recordControl="162" data1="0" data2="28" data3="3" scene="11" syncstatus="changed" uid="2567688292" />
           </record>
           <record sequence="42">
             <device address="BB.66.66" group="6" recordControl="162" data1="0" data2="28" data3="3" scene="11" syncstatus="synced" uid="1522509858" />
@@ -697,7 +697,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -706,10 +706,10 @@
             <device address="AA.11.11" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="2394728804" />
           </record>
           <record sequence="2">
-            <device address="11.22.33" group="4" recordControl="162" data1="51" data2="28" data3="1" scene="16" syncstatus="changed" uid="2876585129" />
+            <device address="11.22.33" group="4" recordControl="162" data1="51" data2="28" data3="1" scene="16" syncstatus="changed" uid="3329746218" />
           </record>
           <record sequence="3">
-            <device address="11.22.33" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="4106107548" />
+            <device address="11.22.33" group="2" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="changed" uid="98984550" />
           </record>
           <record sequence="4">
             <device address="AA.00.00" group="0" recordControl="170" data1="51" data2="28" data3="0" scene="0" syncstatus="synced" uid="3477534837" />
@@ -758,7 +758,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -770,10 +770,10 @@
             <device address="AA.11.11" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="synced" uid="740918530" />
           </record>
           <record sequence="3">
-            <device address="11.22.33" group="4" recordControl="162" data1="76" data2="28" data3="1" scene="16" syncstatus="changed" uid="312972000" />
+            <device address="11.22.33" group="4" recordControl="162" data1="76" data2="28" data3="1" scene="16" syncstatus="changed" uid="3643862305" />
           </record>
           <record sequence="4">
-            <device address="11.22.33" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="1689295713" />
+            <device address="11.22.33" group="2" recordControl="162" data1="153" data2="28" data3="1" scene="1" syncstatus="changed" uid="2882631056" />
           </record>
           <record sequence="5">
             <device address="AA.11.11" group="4" recordControl="162" data1="76" data2="28" data3="1" scene="16" syncstatus="synced" uid="3024636706" />
@@ -948,7 +948,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="0" lastUpdate="1/9/2025 3:47:46 PM" lastStatus="Changed" revision="0" nextRecordToRead="0" />
+        <database sequence="0" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="0" nextRecordToRead="0" />
         <properties lastStatus="Synchronized">
           <p name="operatingFlags">
             <device value="0x28" lastUpdate="1/12/2014 9:33:00 AM" />
@@ -1112,19 +1112,19 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
           </record>
           <record sequence="1">
-            <device address="11.22.33" group="6" recordControl="162" data1="0" data2="28" data3="8" scene="11" syncstatus="changed" uid="2381168128" />
+            <device address="11.22.33" group="6" recordControl="162" data1="0" data2="28" data3="8" scene="11" syncstatus="changed" uid="4012555525" />
           </record>
           <record sequence="2">
             <device address="AA.88.88" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="2" syncstatus="synced" uid="3316777259" />
           </record>
           <record sequence="3">
-            <device address="11.22.33" group="6" recordControl="162" data1="255" data2="28" data3="6" scene="11" syncstatus="changed" uid="427050428" />
+            <device address="11.22.33" group="6" recordControl="162" data1="255" data2="28" data3="6" scene="11" syncstatus="changed" uid="506339146" />
           </record>
           <record sequence="4">
             <device address="BB.22.22" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="synced" uid="3974388577" />
@@ -1154,7 +1154,7 @@
             <device address="AA.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="11" syncstatus="synced" uid="2999894924" />
           </record>
           <record sequence="13">
-            <device address="11.22.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="11" syncstatus="changed" uid="2948087518" />
+            <device address="11.22.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="11" syncstatus="changed" uid="1585327155" />
           </record>
           <record sequence="14">
             <device address="AA.88.88" group="5" recordControl="226" data1="3" data2="28" data3="5" scene="18" syncstatus="synced" uid="1766743764" />
@@ -1193,10 +1193,10 @@
             <device address="AA.77.77" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="4" syncstatus="synced" uid="3155844516" />
           </record>
           <record sequence="26">
-            <device address="11.22.33" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="4" syncstatus="changed" uid="1335611680" />
+            <device address="11.22.33" group="7" recordControl="226" data1="3" data2="28" data3="7" scene="4" syncstatus="changed" uid="779055711" />
           </record>
           <record sequence="27">
-            <device address="11.22.33" group="8" recordControl="162" data1="255" data2="28" data3="7" scene="4" syncstatus="changed" uid="411293497" />
+            <device address="11.22.33" group="8" recordControl="162" data1="255" data2="28" data3="7" scene="4" syncstatus="changed" uid="2050372958" />
           </record>
           <record sequence="28">
             <device address="AA.AA.AA" group="4" recordControl="162" data1="255" data2="28" data3="7" scene="4" syncstatus="synced" uid="3172347022" />
@@ -1226,7 +1226,7 @@
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="20" syncstatus="synced" uid="1415271273" />
           </record>
           <record sequence="37">
-            <device address="11.22.33" group="5" recordControl="250" data1="3" data2="28" data3="5" scene="0" syncstatus="changed" uid="3336320375" />
+            <device address="11.22.33" group="5" recordControl="250" data1="3" data2="28" data3="5" scene="0" syncstatus="changed" uid="2511568544" />
           </record>
           <record sequence="38">
             <device address="BB.22.22" group="5" recordControl="162" data1="255" data2="28" data3="4" scene="20" syncstatus="synced" uid="4028815863" />
@@ -1279,7 +1279,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1313,7 +1313,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1330,7 +1330,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1382,7 +1382,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1430,7 +1430,7 @@
             <device address="AA.00.00" group="4" recordControl="162" data1="255" data2="28" data3="4" scene="12" syncstatus="synced" uid="40234088" />
           </record>
           <record sequence="15">
-            <device address="11.22.33" group="2" recordControl="162" data1="255" data2="28" data3="6" scene="1" syncstatus="changed" uid="1382994255" />
+            <device address="11.22.33" group="2" recordControl="162" data1="255" data2="28" data3="6" scene="1" syncstatus="changed" uid="1573162734" />
           </record>
           <record sequence="16">
             <device address="AA.11.11" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="925210081" />
@@ -1442,7 +1442,7 @@
             <device address="AA.33.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="synced" uid="3464026826" />
           </record>
           <record sequence="19">
-            <device address="11.22.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="3993407757" />
+            <device address="11.22.33" group="6" recordControl="226" data1="3" data2="28" data3="6" scene="1" syncstatus="changed" uid="1890488646" />
           </record>
           <record sequence="20">
             <device address="AA.66.66" group="1" recordControl="162" data1="255" data2="28" data3="3" scene="12" syncstatus="synced" uid="1169790295" />
@@ -1492,7 +1492,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1526,7 +1526,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1543,7 +1543,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1595,7 +1595,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1689,7 +1689,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1698,7 +1698,7 @@
             <device address="AA.11.11" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="4" syncstatus="synced" uid="2810299504" />
           </record>
           <record sequence="2">
-            <device address="11.22.33" group="8" recordControl="162" data1="255" data2="28" data3="1" scene="4" syncstatus="changed" uid="4218066731" />
+            <device address="11.22.33" group="8" recordControl="162" data1="255" data2="28" data3="1" scene="4" syncstatus="changed" uid="2848575876" />
           </record>
           <record sequence="3">
             <device address="AA.AA.AA" group="4" recordControl="162" data1="255" data2="28" data3="1" scene="4" syncstatus="synced" uid="2537990749" />
@@ -1707,7 +1707,7 @@
             <device address="AA.11.11" group="7" recordControl="162" data1="255" data2="28" data3="1" scene="4" syncstatus="synced" uid="628526782" />
           </record>
           <record sequence="5">
-            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="4" syncstatus="changed" uid="3568693520" />
+            <device address="11.22.33" group="1" recordControl="226" data1="3" data2="28" data3="1" scene="4" syncstatus="changed" uid="1652111837" />
           </record>
           <record sequence="6">
             <device address="BB.66.66" group="7" recordControl="162" data1="255" data2="28" data3="1" scene="4" syncstatus="synced" uid="1794422102" />
@@ -1744,7 +1744,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1802,7 +1802,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1860,7 +1860,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1903,7 +1903,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -1944,7 +1944,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1961,7 +1961,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1978,7 +1978,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2081,7 +2081,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2239,7 +2239,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2376,7 +2376,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2551,7 +2551,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2600,7 +2600,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2652,7 +2652,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2714,7 +2714,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2851,7 +2851,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3029,7 +3029,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:11:49 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3078,7 +3078,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3124,7 +3124,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />
@@ -3157,7 +3157,7 @@
             <device address="BB.66.66" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" uid="3079055461" />
           </record>
           <record sequence="10">
-            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="447307496" />
+            <device address="11.22.33" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="1624867378" />
           </record>
           <record sequence="11">
             <device address="BB.66.66" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="17" uid="986885434" />
@@ -3166,7 +3166,7 @@
             <device address="AA.88.88" group="2" recordControl="226" data1="3" data2="28" data3="2" scene="17" uid="3190419690" />
           </record>
           <record sequence="13">
-            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="0" syncstatus="changed" uid="2872991101" />
+            <device address="11.22.33" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="0" syncstatus="changed" uid="290554122" />
           </record>
         </database>
         <properties>
@@ -3319,7 +3319,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="5/21/2025 12:11:49 PM" lastStatus="Changed" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="changed" uid="4200085148" />
@@ -3414,16 +3414,16 @@
         </database>
         <properties lastStatus="Synchronized">
           <p name="operatingFlags">
-            <device value="0x28" lastUpdate="1/9/2025 3:47:46 PM" />
+            <device value="0x28" lastUpdate="5/21/2025 12:11:49 PM" />
           </p>
           <p name="ledDimming">
-            <device value="0x14" lastUpdate="1/9/2025 3:47:46 PM" />
+            <device value="0x14" lastUpdate="5/21/2025 12:11:49 PM" />
           </p>
           <p name="X10House">
-            <device value="0x20" lastUpdate="1/9/2025 3:47:46 PM" />
+            <device value="0x20" lastUpdate="5/21/2025 12:11:49 PM" />
           </p>
           <p name="X10Unit">
-            <device value="0x20" lastUpdate="1/9/2025 3:47:46 PM" />
+            <device value="0x20" lastUpdate="5/21/2025 12:11:49 PM" />
           </p>
         </properties>
       </device>

--- a/UnitTestApp/Refs/Merges/TestAddDeviceLocalAndOther.xml
+++ b/UnitTestApp/Refs/Merges/TestAddDeviceLocalAndOther.xml
@@ -270,7 +270,7 @@
           <channel id="253" />
           <channel id="254" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="-1">
+        <database sequence="0" lastUpdate="5/21/2025 12:22:46 PM" lastStatus="Synchronized" revision="-1">
           <record sequence="0">
             <device address="BB.66.66" group="0" recordControl="226" data1="1" data2="65" data3="67" scene="0" syncstatus="synced" uid="3124031505" />
           </record>
@@ -368,10 +368,10 @@
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="0" data3="4" scene="12" syncstatus="synced" uid="737273190" />
           </record>
           <record sequence="32">
-            <device address="44.55.66" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="794027066" />
+            <device address="44.55.66" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="2603956686" />
           </record>
           <record sequence="33">
-            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="1914450032" />
+            <device address="11.22.33" group="0" recordControl="226" data1="1" data2="32" data3="65" scene="0" syncstatus="synced" uid="361411336" />
           </record>
         </database>
         <properties lastStatus="Synchronized">
@@ -522,7 +522,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="76">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="76">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="255" data2="28" data3="2" scene="0" syncstatus="synced" uid="2299225136" />
@@ -700,7 +700,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.55.55" group="6" recordControl="162" data1="76" data2="28" data3="1" scene="1" syncstatus="synced" uid="657642853" />
@@ -761,7 +761,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="76" data2="28" data3="0" scene="0" syncstatus="synced" uid="2508236334" />
@@ -951,7 +951,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="8" recordControl="226" data1="3" data2="28" data3="8" scene="4" syncstatus="synced" uid="4200085148" />
@@ -1207,7 +1207,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="24">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="24">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="4" scene="0" syncstatus="synced" uid="1784632921" />
@@ -1374,7 +1374,7 @@
         <location value="By door to kitchen" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1408,7 +1408,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Main" lastStatus="Changed">
+          <channel id="3" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1425,7 +1425,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Desks" lastStatus="Changed">
+          <channel id="4" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1477,7 +1477,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="6">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="6">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1372399086" />
@@ -1587,7 +1587,7 @@
         <location value="By door to hallway" room="Den" />
         <customProperties />
         <channels>
-          <channel id="1" name="All ON / OFF" lastStatus="Changed">
+          <channel id="1" name="All ON / OFF" lastStatus="Synchronized">
             <onMask>
               <device value="12" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1621,7 +1621,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Desks" lastStatus="Changed">
+          <channel id="3" name="Desks" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1638,7 +1638,7 @@
               <device value="0" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="4" name="Main" lastStatus="Changed">
+          <channel id="4" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="1" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -1690,7 +1690,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="7">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="7">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2677125792" />
@@ -1784,7 +1784,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="5/21/2025 12:22:46 PM" lastStatus="Changed" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="79398351" />
@@ -1839,7 +1839,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1886143975" />
@@ -1897,7 +1897,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="10">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="10">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="3398566785" />
@@ -1955,7 +1955,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="24" data3="0" scene="0" syncstatus="synced" uid="1864837692" />
@@ -1998,7 +1998,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="583030113" />
@@ -2039,7 +2039,7 @@
         <location value="Right of entry door" room="Master Bedroom" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2056,7 +2056,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="2" name="Dim" lastStatus="Changed">
+          <channel id="2" name="Dim" lastStatus="Synchronized">
             <onMask>
               <device value="0" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2073,7 +2073,7 @@
               <device value="28" lastUpdate="1/3/2022 6:14:05 PM" />
             </rampRate>
           </channel>
-          <channel id="3" name="Bed" lastStatus="Changed">
+          <channel id="3" name="Bed" lastStatus="Synchronized">
             <onMask>
               <device value="32" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2176,7 +2176,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="5">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="5">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="5" scene="0" syncstatus="synced" uid="4085291214" />
@@ -2334,7 +2334,7 @@
         <location value="Left of door to bathroom" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2471,7 +2471,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2867033475" />
@@ -2646,7 +2646,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="2">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="2">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="162" data1="0" data2="0" data3="1" scene="0" syncstatus="synced" uid="686709592" />
@@ -2695,7 +2695,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="2672601137" />
@@ -2747,7 +2747,7 @@
         <channels>
           <channel id="1" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1634048655" />
@@ -2809,7 +2809,7 @@
         <location value="Inside master bath, by door" room="Master Bath" />
         <customProperties />
         <channels>
-          <channel id="1" name="Main" lastStatus="Changed">
+          <channel id="1" name="Main" lastStatus="Synchronized">
             <onMask>
               <device value="128" lastUpdate="1/31/2024 3:33:46 PM" />
             </onMask>
@@ -2946,7 +2946,7 @@
             </rampRate>
           </channel>
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Synchronized" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.00.00" group="0" recordControl="170" data1="0" data2="28" data3="0" scene="0" syncstatus="synced" uid="1031151580" />
@@ -3124,7 +3124,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="0" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:22:46 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="BB.22.22" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="2329724910" />
@@ -3173,7 +3173,7 @@
           <channel id="3" name="Fireplace" />
           <channel id="4" name="All Off" />
         </channels>
-        <database sequence="1" lastUpdate="1/31/2024 3:33:46 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:22:46 PM" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.EE.EE" group="3" recordControl="226" data1="3" data2="28" data3="3" scene="3" uid="161474824" />
@@ -3219,7 +3219,7 @@
           <channel id="3" name="Dim" />
           <channel id="4" name="Fireplace" />
         </channels>
-        <database sequence="1" lastUpdate="10/23/2022 4:42:28 PM" lastStatus="Changed" revision="0">
+        <database sequence="1" lastUpdate="5/21/2025 12:22:46 PM" lastStatus="Changed" revision="0">
           <readResumeData timeStamp="1/1/0001 12:00:00 AM" sequence="0" lastSuccessIndex="0" />
           <record sequence="0">
             <device address="AA.11.11" group="4" recordControl="226" data1="3" data2="28" data3="4" scene="4" syncstatus="changed" uid="3167623054" />
@@ -3274,7 +3274,7 @@
         </properties>
       </device>
       <device insteonID="11.22.33" category="1" subcategory="65" revision="72" engineVersion="2" status="connected" powerline="1" radio="1" hopIfModSyncFails="0" ipk="00.00.00" wattage="0" webDeviceID="0" webGatewayControllerGroup="0" driver="" displayName="New device" active="1">
-        <notes added="1/9/2025 3:53:36 PM" />
+        <notes added="5/21/2025 12:22:46 PM" />
         <location />
         <channels>
           <channel id="1" />
@@ -3286,22 +3286,22 @@
           <channel id="7" />
           <channel id="8" />
         </channels>
-        <database sequence="0" lastUpdate="1/1/0001 12:00:00 AM" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:22:46 PM" lastStatus="Synchronized" revision="0">
           <record sequence="0">
-            <device address="AA.00.00" group="0" recordControl="162" data1="255" data2="28" data3="1" scene="0" syncstatus="synced" uid="2008300590" />
+            <device address="AA.00.00" group="0" recordControl="162" data1="255" data2="28" data3="1" scene="0" syncstatus="synced" uid="3370306110" />
           </record>
           <record sequence="1">
-            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="1673574004" />
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="2967230135" />
           </record>
         </database>
         <properties lastStatus="Synchronized">
           <p name="operatingFlags">
-            <device value="0x08" lastUpdate="1/9/2025 3:53:36 PM" />
+            <device value="0x08" lastUpdate="5/21/2025 12:22:46 PM" />
           </p>
         </properties>
       </device>
       <device insteonID="44.55.66" category="1" subcategory="65" revision="72" engineVersion="2" status="connected" powerline="1" radio="1" hopIfModSyncFails="0" ipk="00.00.00" wattage="0" webDeviceID="0" webGatewayControllerGroup="0" driver="" displayName="New device added by others" active="1">
-        <notes added="1/9/2025 3:53:36 PM" />
+        <notes added="5/21/2025 12:22:46 PM" />
         <location />
         <channels>
           <channel id="1" />
@@ -3313,17 +3313,17 @@
           <channel id="7" />
           <channel id="8" />
         </channels>
-        <database sequence="0" lastUpdate="1/1/0001 12:00:00 AM" revision="0">
+        <database sequence="0" lastUpdate="5/21/2025 12:22:46 PM" lastStatus="Synchronized" revision="0">
           <record sequence="0">
-            <device address="AA.00.00" group="0" recordControl="162" data1="255" data2="28" data3="1" scene="0" syncstatus="synced" uid="856721840" />
+            <device address="AA.00.00" group="0" recordControl="162" data1="255" data2="28" data3="1" scene="0" syncstatus="synced" uid="861433085" />
           </record>
           <record sequence="1">
-            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="33916009" />
+            <device address="00.00.00" group="0" recordControl="0" data1="0" data2="0" data3="0" scene="0" syncstatus="synced" uid="2534339758" />
           </record>
         </database>
         <properties lastStatus="Synchronized">
           <p name="operatingFlags">
-            <device value="0x08" lastUpdate="1/9/2025 3:53:36 PM" />
+            <device value="0x08" lastUpdate="5/21/2025 12:22:46 PM" />
           </p>
         </properties>
       </device>


### PR DESCRIPTION
PR #94 marked databases Synchronized in cases they had not before, and this broke some unit-tests. Fixed by updating the references. 
In addition, removed the lastStatus="Changed" in the original model (changes1.xml) so as to isolate only the changes due to each test.