### PR TITLE
Ensured that Gateways and Scenes where properly updated during a Save operation

### DIFF
--- a/Insteon/Base/Gateway.cs
+++ b/Insteon/Base/Gateway.cs
@@ -46,27 +46,16 @@ public sealed class Gateway
         Port = port;
     }
 
-    public Gateway(House house, string hostName, string macAddress, string ipAddress, string port, string username, string password)
+    public Gateway(House house, string hostName, string macAddress, string ipAddress, string port, string? username, string? password)
+        : this(house, hostName, macAddress, ipAddress, port)
     {
-        this.house = house;
-        MacAddress = macAddress;
-        HostName = hostName;
-        IPAddress = ipAddress;
-        Port = port;
         Username = username;
         Password = password;
     }
 
     internal Gateway(Gateway gateway)
+        : this (gateway.house, gateway.HostName, gateway.MacAddress, gateway.IPAddress, gateway.Port, gateway.Username, gateway.Password)
     {
-        house = gateway.house;
-        DeviceId = gateway.DeviceId;
-        MacAddress = gateway.MacAddress;
-        HostName = gateway.HostName;
-        IPAddress = gateway.IPAddress;
-        Port = gateway.Port;
-        Username = gateway.Username;
-        Password = gateway.Password;
     }
 
     ~Gateway()
@@ -92,6 +81,16 @@ public sealed class Gateway
     public override int GetHashCode()
     {
         return DeviceId.ToInt();
+    }
+
+    internal void CopyFrom(Gateway fromGateway)
+    {
+        MacAddress = fromGateway.MacAddress;
+        HostName = fromGateway.HostName;
+        IPAddress = fromGateway.IPAddress;
+        Port = fromGateway.Port;
+        Username = fromGateway.Username;
+        Password = fromGateway.Password;
     }
 
     internal bool IsIdenticalTo(Gateway other)

--- a/Insteon/Model/House.cs
+++ b/Insteon/Model/House.cs
@@ -30,6 +30,13 @@ public sealed class House
         ModelObserver = new(ModelRecorder);
     }
 
+#if DEBUG
+    // Assign an immutable Id to a house for easier debugging.
+    private static int nextId = 1;
+    public readonly int Id = nextId++;
+    public override string ToString() => $"House - {Id}";
+#endif
+
     public string Name { get; set; } = "";
 
     public string Version { get; set; } = "";

--- a/Insteon/Model/Scene.cs
+++ b/Insteon/Model/Scene.cs
@@ -23,11 +23,15 @@ namespace Insteon.Model;
 // but instead by creating links between each controller and responder
 public sealed class Scene
 {
-    public Scene(Scenes scenes, string name, int id)
+    public Scene(Scenes scenes, int id)
+    {
+        this.Scenes = scenes;
+        this.Id = id;
+    }
+
+    public Scene(Scenes scenes, string name, int id) : this(scenes, id)
     {
         this.name = name;
-        this.Id = id;
-        this.Scenes = scenes; 
     }
 
     /// <summary>

--- a/Insteon/Model/Scenes.cs
+++ b/Insteon/Model/Scenes.cs
@@ -17,293 +17,293 @@
 using Common;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Insteon.Model
+namespace Insteon.Model;
+
+/// <summary>
+/// Represents the list of scenes in the model
+/// </summary>
+public sealed class Scenes : OrderedKeyedList<Scene>
 {
+    public Scenes(House house)
+    {
+        House = house;
+    }
+
+    public House House { get; init; }
 
     /// <summary>
-    /// Represents the list of scenes in the model
+    /// Id of the next scene to be created
     /// </summary>
-    public sealed class Scenes : OrderedKeyedList<Scene>
+    internal int NextSceneID 
     {
-        public Scenes(House house)
+        get => nextSceneID;
+        set 
         {
-            House = house;
+            if (value == nextSceneID) return;
+            nextSceneID = value;
+            observers.ForEach(o => o.ScenesPropertyChanged(this));
+        }
+    }
+    private int nextSceneID;
+
+    // Copy state from another Scenes object in a manner where properties and
+    // collection change notifications are raised to observers
+    internal void CopyFrom(Scenes fromScenes)
+    {
+        NextSceneID = fromScenes.NextSceneID;
+
+        var fromScene2 = new Scenes(House);
+        foreach (var device in fromScenes)
+        {
+            fromScene2.Add(device);
         }
 
-        public House House { get; init; }
-
-        /// <summary>
-        /// Id of the next scene to be created
-        /// </summary>
-        internal int NextSceneID 
+        var scenesToRemove = new List<Scene>();
+        foreach (var scene in this)
         {
-            get => nextSceneID;
-            set 
+            if (fromScene2.TryGetEntry(scene.Id, out var fromScene))
             {
-                if (value == nextSceneID) return;
-                nextSceneID = value;
-                observers.ForEach(o => o.ScenesPropertyChanged(this));
+                scene.CopyFrom(fromScene);
+                fromScene2.Remove(fromScene);
             }
-        }
-        private int nextSceneID;
-
-        // Copy state from another Scenes object in a manner where properties and
-        // collection change notifications are raised to observers
-        internal void CopyFrom(Scenes fromScenes)
-        {
-            NextSceneID = fromScenes.NextSceneID;
-
-            var fromScene2 = new Scenes(House);
-            foreach (var device in fromScenes)
+            else
             {
-                fromScene2.Add(device);
-            }
-
-            var scenesToRemove = new List<Scene>();
-            foreach (var scene in this)
-            {
-                if (fromScene2.TryGetEntry(scene.Id, out var fromScene))
-                {
-                    scene.CopyFrom(fromScene);
-                    fromScene2.Remove(fromScene);
-                }
-                else
-                {
-                    scenesToRemove.Add(scene);
-                }
-            }
-
-            foreach (var scene in scenesToRemove)
-            {
-                Remove(scene);
-            }
-
-            foreach (var scene in fromScene2)
-            {
-                Add(scene);
+                scenesToRemove.Add(scene);
             }
         }
 
-        internal bool IsIdenticalTo(Scenes scenes)
+        foreach (var scene in scenesToRemove)
         {
-            if (NextSceneID != scenes.NextSceneID) return false;
-            if (Count != scenes.Count) return false;
-            for (var i = 0; i < Count; i++)
-            {
-                if (!this[i].IsIdenticalTo(scenes[i])) return false;
-            }
-            return true;
+            Remove(scene);
         }
 
-        internal void OnDeserialized()
+        foreach (var scene in fromScene2)
         {
-            foreach(Scene scene in this)
-            {
-                scene.OnDeserialized();
-            }
+            var newScene = new Scene(this, scene.Id);
+            Add(newScene);
+            newScene.CopyFrom(scene);
+        }
+    }
 
-            AddObserver(House.ModelObserver);
+    internal bool IsIdenticalTo(Scenes scenes)
+    {
+        if (NextSceneID != scenes.NextSceneID) return false;
+        if (Count != scenes.Count) return false;
+        for (var i = 0; i < Count; i++)
+        {
+            if (!this[i].IsIdenticalTo(scenes[i])) return false;
+        }
+        return true;
+    }
+
+    internal void OnDeserialized()
+    {
+        foreach(Scene scene in this)
+        {
+            scene.OnDeserialized();
         }
 
-        /// <summary>
-        /// For observers to subscribe to change notifications
-        /// </summary>
-        /// <param name="observer"></param>
-        public Scenes AddObserver(IScenesObserver observer)
+        AddObserver(House.ModelObserver);
+    }
+
+    /// <summary>
+    /// For observers to subscribe to change notifications
+    /// </summary>
+    /// <param name="observer"></param>
+    public Scenes AddObserver(IScenesObserver observer)
+    {
+        observers.Add(observer);
+        return this;
+    }
+
+    /// <summary>
+    /// For observers to unsubscribe to change notifications
+    /// </summary>
+    /// <param name="observer"></param>
+    public Scenes RemoveObserver(IScenesObserver observer)
+    {
+        observers.Remove(observer);
+        return this;
+    }
+
+    private List<IScenesObserver> observers = new List<IScenesObserver>();
+
+    /// <summary>
+    /// Get a scene object by Id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    public Scene? GetSceneById(int id)
+    {
+        if (TryGetEntry(id, out Scene? scene))
         {
-            observers.Add(observer);
-            return this;
-        }
-
-        /// <summary>
-        /// For observers to unsubscribe to change notifications
-        /// </summary>
-        /// <param name="observer"></param>
-        public Scenes RemoveObserver(IScenesObserver observer)
-        {
-            observers.Remove(observer);
-            return this;
-        }
-
-        private List<IScenesObserver> observers = new List<IScenesObserver>();
-
-        /// <summary>
-        /// Get a scene object by Id
-        /// </summary>
-        /// <param name="id"></param>
-        /// <returns></returns>
-        public Scene? GetSceneById(int id)
-        {
-            if (TryGetEntry(id, out Scene? scene))
-            {
-                return scene;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Same as above with Try pattern
-        /// </summary>
-        /// <param name="id"></param>
-        /// <param name="scene"></param>
-        /// <returns></returns>
-        public bool TryGetSceneById(int id, [NotNullWhen(true)] out Scene? scene)
-        {
-            return TryGetEntry(id, out scene);
-        }
-
-        /// <summary>
-        /// Add a new scene with a given name, with no scene members
-        /// The scene Id is automatically generated
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public Scene AddNewScene(string name)
-        {
-            // Find first available scene Id
-            // Sometimes NextSceneId from the persisted model might be wrong,
-            // ensure we are using an non yet used Id
-            int nextSceneId = NextSceneID;
-            while (GetSceneById(nextSceneId) != null) {nextSceneId++;}
-            NextSceneID = nextSceneId;
-
-            // Now create and add the new Scene
-            Scene scene = new Scene(this, name, NextSceneID++);
-            scene.AddObserver(House.ModelObserver);
-            Add(scene);
             return scene;
         }
 
-        /// <summary>
-        /// Remove a scene and the links associated to it
-        /// </summary>
-        /// <param name="scene"></param>
-        public void RemoveScene(Scene scene)
-        {
-            // This will removes all the links associated to the scene
-            scene.RemoveAllMembers();
+        return null;
+    }
 
-            // Now remove the scene
-            Remove(scene);
-            if (scene.Id == NextSceneID - 1)
+    /// <summary>
+    /// Same as above with Try pattern
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="scene"></param>
+    /// <returns></returns>
+    public bool TryGetSceneById(int id, [NotNullWhen(true)] out Scene? scene)
+    {
+        return TryGetEntry(id, out scene);
+    }
+
+    /// <summary>
+    /// Add a new scene with a given name, with no scene members
+    /// The scene Id is automatically generated
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    public Scene AddNewScene(string name)
+    {
+        // Find first available scene Id
+        // Sometimes NextSceneId from the persisted model might be wrong,
+        // ensure we are using an non yet used Id
+        int nextSceneId = NextSceneID;
+        while (GetSceneById(nextSceneId) != null) {nextSceneId++;}
+        NextSceneID = nextSceneId;
+
+        // Now create and add the new Scene
+        Scene scene = new Scene(this, name, NextSceneID++);
+        scene.AddObserver(House.ModelObserver);
+        Add(scene);
+        return scene;
+    }
+
+    /// <summary>
+    /// Remove a scene and the links associated to it
+    /// </summary>
+    /// <param name="scene"></param>
+    public void RemoveScene(Scene scene)
+    {
+        // This will removes all the links associated to the scene
+        scene.RemoveAllMembers();
+
+        // Now remove the scene
+        Remove(scene);
+        if (scene.Id == NextSceneID - 1)
+        {
+            NextSceneID--;
+        }
+    }
+
+    /// <summary>
+    /// Remove a scene by Id
+    /// </summary>
+    /// <param name="id"></param>
+    public void RemoveSceneById(int id)
+    {
+        var scene = GetSceneById(id);
+        if (scene != null)
+        {
+            RemoveScene(scene);
+        }
+    }
+
+    /// <summary>
+    /// Add a scene to this collection with no other side effects
+    /// </summary>
+    /// <param name="scene"></param>
+    public override void Add(Scene scene)
+    {
+        base.Add(scene);
+        observers.ForEach(o => o.SceneAdded(scene));
+    }
+
+    /// <summary>
+    /// Not supported: Insert a scene to this collection with no other side effects
+    /// </summary>
+    /// <param name="scene"></param>
+    public override void Insert(int seq, Scene scene)
+    {
+        throw new NotImplementedException("Inserting a scene in the Scenes collection is not supported");
+    }
+
+    /// <summary>
+    /// Remove a scene to this collection with no other side effects
+    /// </summary>
+    /// <param name="scene"></param>
+    public override bool Remove(Scene scene)
+    {
+        if (base.Remove(scene))
+        {
+            observers.ForEach(o => o.SceneRemoved(scene));
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Remove all scene members for a given device
+    /// </summary>
+    /// <param name="deviceId">device to remove</param>
+    public void RemoveDevice(InsteonID deviceId)
+    {
+        foreach (Scene scene in this)
+        {
+            List<SceneMember> membersToRemove = new List<SceneMember>();
+            foreach (SceneMember member in scene.Members)
             {
-                NextSceneID--;
+                if (member.DeviceId == deviceId)
+                {
+                    membersToRemove.Add(member);
+                }
+            }
+
+            foreach(var member in membersToRemove)
+            {
+                // No need to remove the links as we are removing the device entirely
+                // and that will remove all the links to that device.
+                scene.RemoveMember(member, removeLinks: false);
             }
         }
+    }
 
-        /// <summary>
-        /// Remove a scene by Id
-        /// </summary>
-        /// <param name="id"></param>
-        public void RemoveSceneById(int id)
+    /// <summary>
+    /// Replace a device by another one in all scene members
+    /// </summary>
+    /// <param name="deviceId">device to replace</param>
+    /// <param name="replacementDeviceId">replacement device</param>
+    public void ReplaceDevice(InsteonID deviceId, InsteonID replacementDeviceId)
+    {
+        foreach (Scene scene in this)
         {
-            var scene = GetSceneById(id);
-            if (scene != null)
+            SceneMembers newSceneMembers = new SceneMembers(scene);
+            foreach (SceneMember member in scene.Members)
             {
-                RemoveScene(scene);
+                newSceneMembers.Add(member.DeviceId == deviceId ? 
+                    new SceneMember(member) { DeviceId = replacementDeviceId } : member);
             }
+            scene.Members = newSceneMembers;
         }
+    }
 
-        /// <summary>
-        /// Add a scene to this collection with no other side effects
-        /// </summary>
-        /// <param name="scene"></param>
-        public override void Add(Scene scene)
+    /// <summary>
+    /// Replicate the scene memberships of a given device to another device
+    /// </summary>
+    /// <param name="deviceId">device to replicate memberships of</param>
+    /// <param name="copyDeviceId">device to replicate memberships for</param>
+    public void CopyDevice(InsteonID deviceId, InsteonID copyDeviceId)
+    {
+        foreach (Scene scene in this)
         {
-            base.Add(scene);
-            observers.ForEach(o => o.SceneAdded(scene));
-        }
-
-        /// <summary>
-        /// Not supported: Insert a scene to this collection with no other side effects
-        /// </summary>
-        /// <param name="scene"></param>
-        public override void Insert(int seq, Scene scene)
-        {
-            throw new NotImplementedException("Inserting a scene in the Scenes collection is not supported");
-        }
-
-        /// <summary>
-        /// Remove a scene to this collection with no other side effects
-        /// </summary>
-        /// <param name="scene"></param>
-        public override bool Remove(Scene scene)
-        {
-            if (base.Remove(scene))
+            List<SceneMember> newSceneMembers = new List<SceneMember>();
+            foreach (SceneMember member in scene.Members)
             {
-                observers.ForEach(o => o.SceneRemoved(scene));
-                return true;
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Remove all scene members for a given device
-        /// </summary>
-        /// <param name="deviceId">device to remove</param>
-        public void RemoveDevice(InsteonID deviceId)
-        {
-            foreach (Scene scene in this)
-            {
-                List<SceneMember> membersToRemove = new List<SceneMember>();
-                foreach (SceneMember member in scene.Members)
+                if (member.DeviceId == deviceId)
                 {
-                    if (member.DeviceId == deviceId)
-                    {
-                        membersToRemove.Add(member);
-                    }
-                }
-
-                foreach(var member in membersToRemove)
-                {
-                    // No need to remove the links as we are removing the device entirely
-                    // and that will remove all the links to that device.
-                    scene.RemoveMember(member, removeLinks: false);
+                    newSceneMembers.Add(new SceneMember(member) { DeviceId = copyDeviceId });
                 }
             }
-        }
-
-        /// <summary>
-        /// Replace a device by another one in all scene members
-        /// </summary>
-        /// <param name="deviceId">device to replace</param>
-        /// <param name="replacementDeviceId">replacement device</param>
-        public void ReplaceDevice(InsteonID deviceId, InsteonID replacementDeviceId)
-        {
-            foreach (Scene scene in this)
+            foreach (var member in newSceneMembers)
             {
-                SceneMembers newSceneMembers = new SceneMembers(scene);
-                foreach (SceneMember member in scene.Members)
-                {
-                    newSceneMembers.Add(member.DeviceId == deviceId ? 
-                        new SceneMember(member) { DeviceId = replacementDeviceId } : member);
-                }
-                scene.Members = newSceneMembers;
-            }
-        }
-
-        /// <summary>
-        /// Replicate the scene memberships of a given device to another device
-        /// </summary>
-        /// <param name="deviceId">device to replicate memberships of</param>
-        /// <param name="copyDeviceId">device to replicate memberships for</param>
-        public void CopyDevice(InsteonID deviceId, InsteonID copyDeviceId)
-        {
-            foreach (Scene scene in this)
-            {
-                List<SceneMember> newSceneMembers = new List<SceneMember>();
-                foreach (SceneMember member in scene.Members)
-                {
-                    if (member.DeviceId == deviceId)
-                    {
-                        newSceneMembers.Add(new SceneMember(member) { DeviceId = copyDeviceId });
-                    }
-                }
-                foreach (var member in newSceneMembers)
-                {
-                    scene.AddMember(member);
-                }
+                scene.AddMember(member);
             }
         }
     }


### PR DESCRIPTION
Fixes #105 closes #105

This is more serious that the bug above appears to be.

When calling `CopyFrom` on `Gateways`, and in some cases on `Scenes`, the target Gateway or Scene would end up pointing to the wrong house (the "from" one as opposed to the target one) after the copy. This would potentially have a bunch of consequences, including sending notifications used to animate the "Sync" icon to the wrong house, and preventing the "from" house to be garbage collected.
 
Changed implementation of `Gateways.CopyFrom` to ensure that the gateways are pointing to the right house model after the copy. This involved implementing `Gateway.CopyFrom`. Since I was there, I also simplified the `Gateway` constructors.

Fixed a bug in `Scenes.CopyFrom` that would also make the scene points to the wrong scene list and house model in certain cases. 

Also added immutable Id to House to help with identifying the house while debugging.