### PR TITLE
Propagate controller and responder status correctly when editing a scene member

### DIFF
--- a/Insteon/Model/Scene.cs
+++ b/Insteon/Model/Scene.cs
@@ -350,9 +350,13 @@ public sealed class Scene
         }
         else
         {
-            // We are just editing the data in the existing scene member
+            // We are either expanding this member to controller and responder 
+            // (from either controller or responder), and/or changing the data.
+            Debug.Assert(newMember.IsController || newMember.IsResponder);
             newMember = new SceneMember(replacedMember)
             {
+                IsController = newMember.IsController,
+                IsResponder = newMember.IsResponder,
                 Data1 = newMember.Data1,
                 Data2 = newMember.Data2,
                 Data3 = newMember.Data3

--- a/Insteon/Model/SceneMember.cs
+++ b/Insteon/Model/SceneMember.cs
@@ -102,8 +102,7 @@ public sealed class SceneMember
     public int OnLevel { get => Data1; init => Data1 = (byte)value; }
     public int RampRate { get => Data2; init => Data2 = (byte)value; }
 
-    public int Tag { get; init; }
-
     // Not Used at this time. Only here to round-trip back to houselinc.xml
+    public int Tag { get; init; }
     public string Status { get; init; } = null!;
 }


### PR DESCRIPTION
When editing a scene member and changing only the controller or responder status, we would not propagate the new values to the edited member. This is now fixed.