### PR TITLE
Allowed 3-line status bar

### DIFF
--- a/UnoApp/Controls/StatusBar.xaml
+++ b/UnoApp/Controls/StatusBar.xaml
@@ -26,7 +26,7 @@
             VerticalAlignment="Center"
             TextWrapping="Wrap"
             MinHeight="48"
-            MaxLines="2"/>
+            MaxLines="3"/>
         <Button
             Grid.Column="1"
             Tag="ConfirmUserAction"


### PR DESCRIPTION
Allowed 3 lines of text on the status bar to accommodate longer log messages.