### PR TITLE
Upgraded to Uno 6

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -4,7 +4,7 @@
       net8.0-android;
       net8.0-ios;
       net8.0-maccatalyst;
-      net8.0-windows10.0.22621;
+      net8.0-windows10.0.26100;
       net8.0-desktop;
       net8.0-browserwasm;
     </TargetFrameworks>
@@ -40,7 +40,7 @@
     the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
     must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
     -->
-    <!-- <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" /> -->
+    <!-- <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.26100" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.26100" /> -->
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,8 +17,5 @@
   </PropertyGroup>
 
   <!-- See https://aka.platform.uno/using-uno-sdk#implicit-packages for more information regarding the Implicit Packages version properties. -->
-  <PropertyGroup>
-    <WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
-  </PropertyGroup>
 </Project>
 

--- a/Insteon/Insteon.csproj
+++ b/Insteon/Insteon.csproj
@@ -4,7 +4,7 @@
       net8.0-android;
       net8.0-ios;
       net8.0-maccatalyst;
-      net8.0-windows10.0.22621;
+      net8.0-windows10.0.26100;
       net8.0-desktop;
       net8.0-browserwasm;
     </TargetFrameworks>

--- a/UnitTestApp/UnitTestApp.csproj
+++ b/UnitTestApp/UnitTestApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.22621</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>UnitTestApp</RootNamespace>
     <Platforms>x86;x64;ARM64</Platforms>

--- a/UnoApp/Platforms/Desktop/Program.cs
+++ b/UnoApp/Platforms/Desktop/Program.cs
@@ -13,24 +13,15 @@
    limitations under the License.
 */
 
-using Uno.UI.Runtime.Skia;
-
 namespace UnoApp;
 public class Program
 {
-    [STAThread]
-    public static void Main(string[] args)
+    private static App? _app;
+
+    public static int Main(string[] args)
     {
-        App.InitializeLogging();
+        Microsoft.UI.Xaml.Application.Start(_ => _app = new App());
 
-        var host = SkiaHostBuilder.Create()
-            .App(() => new App())
-            .UseX11()
-            .UseLinuxFrameBuffer()
-            .UseMacOS()
-            .UseWindows()
-            .Build();
-
-        host.Run();
+        return 0;
     }
 }

--- a/UnoApp/UnoApp.csproj
+++ b/UnoApp/UnoApp.csproj
@@ -4,7 +4,7 @@
       net8.0-android;
       net8.0-ios;
       net8.0-maccatalyst;
-      net8.0-windows10.0.22621;
+      net8.0-windows10.0.26100;
       net8.0-desktop;
       net8.0-browserwasm;
     </TargetFrameworks>

--- a/ViewModel/ViewModel.csproj
+++ b/ViewModel/ViewModel.csproj
@@ -4,7 +4,7 @@
       net8.0-android;
       net8.0-ios;
       net8.0-maccatalyst;
-      net8.0-windows10.0.22621;
+      net8.0-windows10.0.26100;
       net8.0-desktop;
       net8.0-browserwasm;
     </TargetFrameworks>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,14 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "5.6.51"
+    "Uno.Sdk": "6.0.110"
+  },
+
+  "sdk": {
+    // TODO: Revert to allowPrerelease line below when https://github.com/dotnet/sdk/issues/49180 is resolved.
+    "version": "9.0.204",
+    "rollForward": "latestPatch"
+
+    //"allowPrerelease": false,
   }
 }


### PR DESCRIPTION
Moved to Uno.Sdk 6.0.100
Moved to minimum net8.0-windows10.0.26100.
Note the temporary Win.SDK workaround:
```
    // TODO: Revert to allowPrerelease line below when https://github.com/dotnet/sdk/issues/49180 is resolved.
    "version": "9.0.204",
    "rollForward": "latestPatch"

    //"allowPrerelease": false,
```