### PR TITLE
Ensured that new devices or new scenes are shown and in view

### DIFF
--- a/UnoApp/Dialogs/NewSceneDialog.xaml.cs
+++ b/UnoApp/Dialogs/NewSceneDialog.xaml.cs
@@ -30,16 +30,14 @@ public sealed partial class NewSceneDialog : ContentDialog, INotifyPropertyChang
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 
-    public NewSceneDialog(XamlRoot xamlRoot, SceneListViewModel sceneListViewModel)
+    public NewSceneDialog(XamlRoot xamlRoot)
     {
         this.XamlRoot = xamlRoot;
         this.InitializeComponent();
-        this.sceneListViewModel = sceneListViewModel;
     }
 
     private void ContentDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
-        sceneListViewModel.AddNewScene(NewSceneName);
     }
 
     private void ContentDialog_SecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
@@ -64,6 +62,4 @@ public sealed partial class NewSceneDialog : ContentDialog, INotifyPropertyChang
         }
     }
     private string newSceneName = string.Empty;
-
-    private SceneListViewModel sceneListViewModel;
 }

--- a/UnoApp/Views/Devices/DeviceDetailsPage.xaml.cs
+++ b/UnoApp/Views/Devices/DeviceDetailsPage.xaml.cs
@@ -91,7 +91,7 @@ public sealed partial class DeviceDetailsPage : DeviceDetailsPageBase
             var deviceViewModel = DeviceViewModel.GetOrCreateById(Holder.House, deviceId);
             if (deviceViewModel != null)
             {
-                // Navigate to the detail page for the copied device
+                // Navigate to the detail page for the new device
                 Frame.Navigate(typeof(DeviceDetailsPage), deviceViewModel.ItemKey, new DrillInNavigationTransitionInfo());
                 break;
             }

--- a/UnoApp/Views/Devices/DeviceListPage.xaml
+++ b/UnoApp/Views/Devices/DeviceListPage.xaml
@@ -1,16 +1,17 @@
-﻿<!-- Copyright 2022 Christian Fortini
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+﻿<!--
+    Copyright 2022 Christian Fortini
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 -->
 
 <local:DeviceListPageBase

--- a/UnoApp/Views/Devices/DeviceListPage.xaml.cs
+++ b/UnoApp/Views/Devices/DeviceListPage.xaml.cs
@@ -128,11 +128,19 @@ public sealed partial class DeviceListPage : DeviceListPageBase
                 break;
             }
 
-            // If we have a new device view model, select it and return
+            // If we have a new device view model, enesure it's shown, selected and in view
             var deviceViewModel = DeviceViewModel.GetOrCreateById(Holder.House, deviceId);
             if (deviceViewModel != null)
             {
+                // The NewDeviceDialog added the device to the model, but the DeviceListViewModel
+                // model observer might or might not have added to the list of device view models.
+                // If not, add it here, so that we can show it to the user.fl
+                if (!deviceListViewModel.Items.Contains(deviceViewModel))
+                {
+                    deviceListViewModel.Items.Add(deviceViewModel);
+                }
                 SelectedItem = deviceViewModel;
+                ItemListView.ScrollIntoView(SelectedItem);
                 break;
             }
 
@@ -184,11 +192,17 @@ public sealed partial class DeviceListPage : DeviceListPageBase
                 break;
 
             // If we have a view model for the replacement device, proceed with the replacement
-            var relacementDeviceViewModel = DeviceViewModel.GetOrCreateById(Holder.House, replacementDeviceId);
-            if (relacementDeviceViewModel != null && SelectedItem != null)
+            var replacementDeviceViewModel = DeviceViewModel.GetOrCreateById(Holder.House, replacementDeviceId);
+            if (replacementDeviceViewModel != null && SelectedItem != null)
             {
+                // See AddDevice_Click for comments
+                if (deviceListViewModel.Items.Contains(replacementDeviceViewModel))
+                {
+                    deviceListViewModel.Items.Add(replacementDeviceViewModel);
+                }
                 SelectedItem.ReplaceDevice(replacementDeviceId);
-                SelectedItem = relacementDeviceViewModel;
+                SelectedItem = replacementDeviceViewModel;
+                ItemListView.ScrollIntoView(SelectedItem);
                 break;
             }
 
@@ -205,7 +219,7 @@ public sealed partial class DeviceListPage : DeviceListPageBase
         InsteonID? copyDevice = null;
         while (true)
         {
-            // See ReplaceDevice_Click for comments
+            // See AddDevice_Click for comments
             copyDevice = await ShowNewDeviceDialog($"Copy {SelectedItem?.DisplayNameAndId} to Device", "Copy", copyDevice, showPriorError);
             if (copyDevice == null || copyDevice.IsNull)
                 break;
@@ -213,8 +227,13 @@ public sealed partial class DeviceListPage : DeviceListPageBase
             var copyDeviceViewModel = DeviceViewModel.GetOrCreateById(Holder.House, copyDevice);
             if (copyDeviceViewModel != null && SelectedItem != null)
             {
+                if (deviceListViewModel.Items.Contains(copyDeviceViewModel))
+                {
+                    deviceListViewModel.Items.Add(copyDeviceViewModel);
+                }
                 SelectedItem.CopyDevice(copyDevice);
                 SelectedItem = copyDeviceViewModel;
+                ItemListView.ScrollIntoView(SelectedItem);
                 break;
             }
 

--- a/UnoApp/Views/Scenes/SceneListPage.xaml
+++ b/UnoApp/Views/Scenes/SceneListPage.xaml
@@ -1,16 +1,17 @@
-﻿<!-- Copyright 2022 Christian Fortini
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+﻿<!--
+    Copyright 2022 Christian Fortini
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 -->
 
 <local:SceneListPageBase

--- a/UnoApp/Views/Scenes/SceneListPage.xaml.cs
+++ b/UnoApp/Views/Scenes/SceneListPage.xaml.cs
@@ -66,8 +66,18 @@ public sealed partial class SceneListPage : SceneListPageBase
         {
             throw new InvalidOperationException("XamlRoot is null");
         }
-        NewSceneDialog dialog = new NewSceneDialog(this.XamlRoot, sceneListViewModel);
-        await dialog.ShowAsync();
+        NewSceneDialog dialog = new NewSceneDialog(this.XamlRoot);
+        if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+        {
+            if (dialog.NewSceneName != null && dialog.NewSceneName != string.Empty)
+            {
+                // Add the scene to the model and the scene view model to this list,
+                // select it and bring it in view
+                var sceneViewModel = sceneListViewModel.AddNewScene(dialog.NewSceneName);
+                sceneListViewModel.SelectedItem = sceneViewModel;
+                ItemListView.ScrollIntoView(sceneViewModel);
+            }
+        }
     }
 
     private async void RemoveSceneBtnClick(object sender, RoutedEventArgs e)

--- a/ViewModel/Scenes/SceneListViewModel.cs
+++ b/ViewModel/Scenes/SceneListViewModel.cs
@@ -130,13 +130,14 @@ public class SceneListViewModel : ItemListViewModel<SceneViewModel>, IScenesObse
     }
 
     /// <summary>
-    /// Add a new scene and sceneViewModel to this list
-    /// Notification coming through the observer will add the sceneViewModel to the list
+    /// Add a new scene to the model 
+    /// and let the observer add the sceneViewModel to this list
     /// </summary>
     /// <param name="name"></param>
-    public void AddNewScene(string name)
+    public SceneViewModel? AddNewScene(string name)
     {
         Scene scene = scenes.AddNewScene(name);
+        return GetSceneViewModelById(scene.Id);
     }
 
     /// <summary>


### PR DESCRIPTION
This change ensures that when adding a device or a scene, its view model will be added to the presented list of view models and selected and brought into view, regardless of the filtering on that list. 
This change also simplifies the `NewSceneDialog`, which now just return a scene name. It's now up to the caller to add the new scene to the model and the view model.