### PR TITLE
Handle last known to be disconnected device during sync

### DIFF
--- a/Insteon/Model/Devices.cs
+++ b/Insteon/Model/Devices.cs
@@ -612,7 +612,7 @@ public sealed class Devices : OrderedKeyedList<Device>
 
                     if (device != null)
                     {
-                        if (device.IsRemoteLinc && !device.Snoozed && device.DeviceNeedsSync)
+                        if (device.IsRemoteLinc && !device.Snoozed && device.NeedsSync)
                         {
                             // If the device needs sync but requires user action, ensure it's in the list of devices needing user action
                             if (!syncContext.devicesNeedingUserAction.Contains(device))


### PR DESCRIPTION
Now handling the case when during sync a device is last known not to be connected by pinging the device and requesting a new sync pass if the ping succeeds. Otherwise, device marked disconnected for whatever reason will never have a chance to sync again, until directly viewed by the user (which will ping a potentially reconnect them). 

Also simplified DeviceNeedsSync and renamed to NeedsSync since it's a method of Device.