### PR TITLE
Workaround to make the `LoadControl` at top of Device view work on Uno. 

### DIFF
--- a/UnoApp/Views/Devices/DeviceStatusView.xaml
+++ b/UnoApp/Views/Devices/DeviceStatusView.xaml
@@ -30,7 +30,9 @@
     <ContentControl.ContentTemplate>
         <DataTemplate x:DataType="vm:DeviceViewModel">
             <StackPanel>
-                <StackPanel x:Name="DeviceStatusConnectedView" x:Load="{x:Bind IsConnected, Mode=OneWay}">
+                <!-- Using Visibility because with x:Load the binding to events LoadFullOn, LoadOn, LoadOff
+                does not work (https://github.com/Lakeside-Apps/HouzLinc/issues/124)-->
+                <StackPanel x:Name="DeviceStatusConnectedView" Visibility="{x:Bind IsConnected, Mode=OneWay}">
                     <Border
                         Background="{StaticResource DeviceStampColor}"
                         CornerRadius="10"


### PR DESCRIPTION
Issue #124

It appears that on Uno, binding the events of a content control in a subtree with the `x:Load` attribute does not work. The event handlers are null despite the binding. This all works just fine on WindowsAppSdk (WinUI3). 

Replacing `x:Load` by `Visibility` appears to fix the issue on WindowsAPpSdk and Uno based platforms, so going with that for now, and I will create a simple repro to investigate further.