### PR TITLE
Better fix to make the `LoadControl` in Device view work on Uno.

### DIFF
--- a/UnoApp/Controls/LoadController.xaml.cs
+++ b/UnoApp/Controls/LoadController.xaml.cs
@@ -70,25 +70,55 @@ public sealed partial class LoadController: UserControl, INotifyPropertyChanged
         DependencyProperty.Register(nameof(Level), typeof(double), typeof(LoadController), 
             new PropertyMetadata(0.0d, new PropertyChangedCallback(OnLevelChanged)));
 
-    public event RoutedEventHandler? LoadFullOn;
-    public event RoutedEventHandler? LoadOn;
-    public event RoutedEventHandler? LoadOff;
+    /// <summary>
+    /// Command to turn the load on to a given level
+    /// </summary>
+    public ICommand LoadOnCommand
+    {
+        get => (ICommand)GetValue(LoadOnCommandProperty);
+        set => SetValue(LoadOnCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty LoadOnCommandProperty =
+    DependencyProperty.Register(
+        nameof(LoadOnCommand),
+        typeof(ICommand),
+        typeof(LoadController),
+        new PropertyMetadata(null)
+    );
+
+    /// <summary>
+    /// Command to turn the load off
+    /// </summary>
+    public ICommand LoadOffCommand
+    {
+        get => (ICommand)GetValue(LoadOffCommandProperty);
+        set => SetValue(LoadOffCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty LoadOffCommandProperty =
+    DependencyProperty.Register(
+        nameof(LoadOffCommand),
+        typeof(ICommand),
+        typeof(LoadController),
+        new PropertyMetadata(null)
+    );
 
     private void RaiseLightOnEvent()
     {
-        LoadOn?.Invoke(this, null);
+        LoadOnCommand.Execute(Level);
     }
 
     private void RaiseLightOnFullEvent()
     {
         Level = 1.0;
-        LoadFullOn?.Invoke(this, null);
+        LoadOnCommand.Execute(Level);
     }
 
     private void RaiseLightOffEvent()
     {
         Level = 0;
-        LoadOff?.Invoke(this, null);
+        LoadOffCommand.Execute(null);
     }
 
     // Bindable to XAML UI

--- a/UnoApp/Views/Devices/DeviceListPage.xaml
+++ b/UnoApp/Views/Devices/DeviceListPage.xaml
@@ -243,9 +243,8 @@
                             win:ToolTipService.ToolTip="Turn load on or off"
                             x:Load="{x:Bind IsOnOffButtonShown, Mode=OneWay}"
                             IsSliderVisible="False"
-                            LoadFullOn="{x:Bind LightFullOn}"
-                            LoadOn="{x:Bind LightOn}"
-                            LoadOff="{x:Bind LightOff}"/>
+                            LoadOnCommand="{x:Bind LightOnCommand}"
+                            LoadOffCommand="{x:Bind LightOffCommand}"/>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/UnoApp/Views/Devices/DeviceStatusView.xaml
+++ b/UnoApp/Views/Devices/DeviceStatusView.xaml
@@ -30,9 +30,7 @@
     <ContentControl.ContentTemplate>
         <DataTemplate x:DataType="vm:DeviceViewModel">
             <StackPanel>
-                <!-- Using Visibility because with x:Load the binding to events LoadFullOn, LoadOn, LoadOff
-                does not work (https://github.com/Lakeside-Apps/HouzLinc/issues/124)-->
-                <StackPanel x:Name="DeviceStatusConnectedView" Visibility="{x:Bind IsConnected, Mode=OneWay}">
+                <StackPanel x:Name="DeviceStatusConnectedView" x:Load="{x:Bind IsConnected, Mode=OneWay}">
                     <Border
                         Background="{StaticResource DeviceStampColor}"
                         CornerRadius="10"
@@ -42,9 +40,8 @@
                         <ctl:LoadController
                             Margin="5,10,10,10"
                             IsSliderVisible="True"
-                            LoadFullOn="{x:Bind LightFullOn}"
-                            LoadOn="{x:Bind LightOn}"
-                            LoadOff="{x:Bind LightOff}"
+                            LoadOnCommand="{x:Bind LightOnCommand}"
+                            LoadOffCommand="{x:Bind LightOffCommand}"
                             Level="{x:Bind LightOnLevel, Mode=TwoWay}"/>
                     </Border>
                 </StackPanel>

--- a/ViewModel/Base/CommandManager.cs
+++ b/ViewModel/Base/CommandManager.cs
@@ -1,0 +1,11 @@
+// Obtained from GitHub Copilot
+
+public static class CommandManager
+{
+    public static event EventHandler? RequerySuggested;
+
+    public static void InvalidateRequerySuggested()
+    {
+        RequerySuggested?.Invoke(null, EventArgs.Empty);
+    }
+}

--- a/ViewModel/Base/RelayCommand.cs
+++ b/ViewModel/Base/RelayCommand.cs
@@ -1,0 +1,32 @@
+// Obtained from GitHub Copilot
+
+public class RelayCommand : ICommand
+{
+    private readonly Action<object?> _execute;
+    private readonly Func<object?, bool>? _canExecute;
+
+    public RelayCommand(Action execute, Func<bool>? canExecute = null)
+        : this(
+            execute != null ? _ => execute() : throw new ArgumentNullException(nameof(execute)),
+            canExecute != null ? _ => canExecute() : null)
+    {
+    }
+
+    public RelayCommand(Action<object?> execute, Func<object?, bool>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke(parameter) ?? true;
+
+    public void Execute(object? parameter) => _execute(parameter);
+
+    public event EventHandler? CanExecuteChanged
+    {
+        add { CommandManager.RequerySuggested += value; }
+        remove { CommandManager.RequerySuggested -= value; }
+    }
+
+    public void RaiseCanExecuteChanged() => CommandManager.InvalidateRequerySuggested();
+}

--- a/ViewModel/Devices/DeviceViewModel.cs
+++ b/ViewModel/Devices/DeviceViewModel.cs
@@ -33,6 +33,8 @@ public class DeviceViewModel : LinkHostViewModel, IDeviceObserver, IRoomsObserve
     // Please use GetOrCreate methods to create the proper type of view model
     public DeviceViewModel(Device device) : base(device)
     {
+        LightOnCommand = new RelayCommand(LightOn);
+        LightOffCommand = new RelayCommand(LightOff);
     }
 
     // Helper to create the proper DeviceViewModel type for a given device
@@ -645,19 +647,17 @@ public class DeviceViewModel : LinkHostViewModel, IDeviceObserver, IRoomsObserve
     public bool IsGatewayError => DeviceConnectionStatus == Device.ConnectionStatus.GatewayError;
 
     /// <summary>
-    /// For a light controller device, turns light on at current requested level
+    /// Commands for load controller devices
     /// </summary>
-    public void LightOn()
-    {
-        Device.ScheduleLightOn(LightOnLevel);
-    }
+    public ICommand LightOnCommand { get; }
+    public ICommand LightOffCommand { get; }
 
     /// <summary>
-    /// For a light controller device, turns light on at full level
+    /// For a light controller device, turns light on at current requested level
     /// </summary>
-    public void LightFullOn()
+    public void LightOn(object? level)
     {
-        Device.ScheduleLightOn(1.0d);
+        Device.ScheduleLightOn((level != null) ? (double)level : 1.0d);
     }
 
     /// <summary>


### PR DESCRIPTION
As stated in PR #125, binding to an event in the view model does not work on Uno if there is an x:Load in the ancestor chain (it does work in WinUI3). Since whether binding to an event in the view model should work or not seems unclear, I changed the events to commands, which appears to be the recommended way to handle this.

I changed `LoadFullOn`, `LoadOn`, `LoadOff` events to commands instead and adapted the dependent code accordingly.

Since commands can easily pass a parameter, I removed the `LoadfullOnCommand` and instead we use `LoadOnCommand` with a parameter indicating the level, which should be 1.0d for full on.
