### PR TITLE
After user adds a new link, bring it into view.

### DIFF
--- a/UnoApp/Utils/XAMLHelpers.cs
+++ b/UnoApp/Utils/XAMLHelpers.cs
@@ -13,6 +13,7 @@
    limitations under the License.
 */
 
+using System.Diagnostics;
 using Microsoft.UI.Dispatching;
 using UnoApp.Controls;
 using Windows.Foundation;
@@ -128,14 +129,26 @@ public static class XAMLHelpers
     }
 
     /// <summary>
+    /// Alignment options for scrolling an element into view within a ScrollViewer.
+    /// </summary>
+    public enum ScrollIntoViewAlignment
+    {
+        Top,
+        Bottom,
+        Center
+    }
+
+    /// <summary>
     /// Scroll an item of an ItemsControl into view using a either the ScrollViewer
     /// of the ItemsControl or another one in its anscestor chain.
+    /// Option to align at the top, center, or bottom of the viewport.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="scrollViewer"></param>
     /// <param name="itemsControl"></param>
     /// <param name="item"></param>
-    public static void ScrollItemIntoView<T>(ScrollViewer scrollViewer, ItemsControl itemsControl, T item)
+    /// <param name="alignment"></param>
+    public static void ScrollItemIntoView<T>(ScrollViewer scrollViewer, ItemsControl itemsControl, T item, ScrollIntoViewAlignment alignment)
     {
         if (itemsControl == null || item == null)
             return;
@@ -145,18 +158,8 @@ public static class XAMLHelpers
         if (container != null)
         {
             // Scroll the item into view
-            ScrollElementIntoView(scrollViewer, container, ScrollIntoViewAlignment.Center);
+            ScrollElementIntoView(scrollViewer, container, alignment);
         }
-    }
-
-    /// <summary>
-    /// Alignment options for scrolling an element into view within a ScrollViewer.
-    /// </summary>
-    public enum ScrollIntoViewAlignment
-    {
-        Top,
-        Bottom,
-        Center
     }
 
     /// <summary>

--- a/UnoApp/Views/Links/LinkHostViews.xaml
+++ b/UnoApp/Views/Links/LinkHostViews.xaml
@@ -124,6 +124,7 @@
 
             <DataTemplate x:Key="DeviceLinkListView" x:DataType="vm:LinkHostViewModel">
                 <GridView
+                    x:Name="DeviceLinkGridView"
                     Margin="5,0,5,0"
                     ItemContainerStyle="{StaticResource CustomGridViewItemExpanded}"
                     ItemTemplateSelector="{StaticResource LinkTemplateSelector}"

--- a/UnoApp/Views/Links/LinkHostViews.xaml.cs
+++ b/UnoApp/Views/Links/LinkHostViews.xaml.cs
@@ -18,6 +18,7 @@ using UnoApp.Views.Devices;
 using UnoApp.Views.Hub;
 using Microsoft.UI.Xaml.Media.Animation;
 using ViewModel.Links;
+using ViewModel.Base;
 
 namespace UnoApp.Views.Links;
 
@@ -121,6 +122,7 @@ public sealed partial class LinkHostViews : ContentControl
             if (await dialog.ShowAsync() == ContentDialogResult.Primary)
             {
                 lhvm.ControllerLinks.AddNewLink(newLink);
+                ShowNewLink(fe, lhvm, newLink, "ControllerLinkGridView");
             }
         }
     }
@@ -139,6 +141,7 @@ public sealed partial class LinkHostViews : ContentControl
             if (await dialog.ShowAsync() == ContentDialogResult.Primary)
             {
                 lhvm.ResponderLinks.AddNewLink(newLink);
+                ShowNewLink(fe, lhvm, newLink, "ResponderLinkGridView");
             }
         }
     }
@@ -161,7 +164,38 @@ public sealed partial class LinkHostViews : ContentControl
             if (await dialog.ShowAsync() == ContentDialogResult.Primary)
             {
                 lhvm.ResponderLinks.AddNewLink(newLink);
+                ShowNewLink(fe, lhvm, newLink, "DeviceLinkGridView");
             }
+        }
+    }
+
+    // Helper to bring into view and select a link in the list of LinkViewModels
+    private void ShowNewLink(FrameworkElement fe, LinkHostViewModel lhvm, LinkViewModel newLink, string gridViewName)
+    {
+        // Retrieve the actual LinkViewModel instance in the list of the newly added link.
+        var newLinkIdx = lhvm.ResponderLinks.IndexOf(newLink);
+        if (newLinkIdx != -1)
+        {
+            newLink = lhvm.ResponderLinks[newLinkIdx];
+
+            // Delay the scrolling a bit to let the UI catch up
+            UIScheduler.Instance.AddJob("Showing newly added link", () =>
+            {
+                // Find the scroll viewer and grid view
+                var scrollViewer = XAMLHelpers.FindVisualAncestor<ScrollViewer>(fe);
+                if (scrollViewer != null)
+                {
+                    var gridView = XAMLHelpers.FindElementByName(scrollViewer, gridViewName) as GridView;
+                    if (gridView != null)
+                    {
+                        gridView.SelectedItem = newLink;
+                        XAMLHelpers.ScrollItemIntoView(scrollViewer, gridView, newLink, 
+                            XAMLHelpers.ScrollIntoViewAlignment.Center);
+                    }
+                }
+                return true;
+            }, delay: TimeSpan.FromMilliseconds(100));
+
         }
     }
 

--- a/UnoApp/Views/Scenes/SceneView.xaml.cs
+++ b/UnoApp/Views/Scenes/SceneView.xaml.cs
@@ -54,7 +54,7 @@ public sealed partial class SceneView : ContentControl
                     newMember = svm.SceneMembers[newMemberIdx];
 
                     // Delay the scrolling a bit to let the UI catch up
-                    UIScheduler.Instance.AddJob("", () =>
+                    UIScheduler.Instance.AddJob("Showing newly added scene", () =>
                     {
                         // To bring the new member into view, this is the scroller we will scroll 
                         var scrollViewer = XAMLHelpers.FindVisualAncestorByName(fe, "SceneScrollViewer") as ScrollViewer;
@@ -66,7 +66,7 @@ public sealed partial class SceneView : ContentControl
                             if (gridView != null)
                             {
                                 gridView.SelectedItem = newMember;
-                                XAMLHelpers.ScrollItemIntoView(scrollViewer, gridView, newMember);
+                                XAMLHelpers.ScrollItemIntoView(scrollViewer, gridView, newMember, XAMLHelpers.ScrollIntoViewAlignment.Center);
                             }
                         }
                         return true;

--- a/ViewModel/Hub/HubChannelViewModel.cs
+++ b/ViewModel/Hub/HubChannelViewModel.cs
@@ -110,14 +110,6 @@ public sealed class HubChannelViewModel : LinkHostViewModel, IChannelObserver
     {
         base.ActiveStateChanged();
         OnPropertyChanged(nameof(IsOnOffButtonShown));
-        if (IsActive)
-        {
-            channel.House.Hub?.AllLinkDatabase.AddObserver(this);
-        }
-        else
-        {
-            channel.House.Hub?.AllLinkDatabase.RemoveObserver(this);
-        }
     }
 
     // Channel this ViewModel is for

--- a/ViewModel/Links/LinkHostViewModel.cs
+++ b/ViewModel/Links/LinkHostViewModel.cs
@@ -202,6 +202,10 @@ public abstract class LinkHostViewModel : ItemViewModel, IAllLinkDatabaseObserve
             {
                 linkListViewModel[index] = new LinkViewModel(linkListViewModel, newRecord);
             }
+            else
+            {
+                linkListViewModel.Add(new LinkViewModel(linkListViewModel, newRecord));
+            }
         }
         RecordListChanged();
     }
@@ -297,7 +301,6 @@ public abstract class LinkHostViewModel : ItemViewModel, IAllLinkDatabaseObserve
                     ControllerLinks = await Task.Run(() => { return BuildLinkList(forControllers: true); });
                     controllerLinkJob = null;
                     ControllerLinks.Changed = false;
-                    Device.AllLinkDatabase.AddObserver(this);
                     return true;
                 },
                 completionCallback: null, group: null,
@@ -332,7 +335,6 @@ public abstract class LinkHostViewModel : ItemViewModel, IAllLinkDatabaseObserve
                     ResponderLinks = await Task.Run(() => { return BuildLinkList(forControllers: false); });
                     responderLinkJob = null;
                     ResponderLinks.Changed = false;
-                    Device.AllLinkDatabase.AddObserver(this);
                     return true;
                 },
                 completionCallback: null, group: null,
@@ -377,7 +379,6 @@ public abstract class LinkHostViewModel : ItemViewModel, IAllLinkDatabaseObserve
                         IsSourceGrouped = true
                     };
 
-                    Device.AllLinkDatabase.AddObserver(this);
                     linkJob = null;
                     return true;
                 },
@@ -421,6 +422,11 @@ public abstract class LinkHostViewModel : ItemViewModel, IAllLinkDatabaseObserve
         if (IsActive)
         {
             ScheduleRebuildLinksIfNecessary(cancelPendingJob: true);
+            Device.AllLinkDatabase.AddObserver(this);
+        }
+        else
+        {
+            Device.AllLinkDatabase.RemoveObserver(this);
         }
     }
 

--- a/ViewModel/Links/LinkViewModel.cs
+++ b/ViewModel/Links/LinkViewModel.cs
@@ -99,6 +99,25 @@ public class LinkViewModel : CollectionItemViewModel<LinkListViewModel, LinkView
         SceneId = linkViewModel.SceneId;
     }
 
+    public override bool Equals(object? obj)
+    {
+        return obj is LinkViewModel linkViewModel &&
+            DestDeviceId.Equals(linkViewModel.DestDeviceId) &&
+            Group == linkViewModel.Group &&
+            IsController == linkViewModel.IsController &&
+            IsRemoved == linkViewModel.IsRemoved &&
+            IsSynchronized == linkViewModel.IsSynchronized &&
+            data1 == linkViewModel.data1 &&
+            data2 == linkViewModel.data2 &&
+            data3 == linkViewModel.data3 &&
+            SceneId == linkViewModel.SceneId;
+    }
+
+    public override int GetHashCode()
+    {
+        return DestDeviceId.ToInt();
+    }
+
     /// <summary>
     /// Produces a LinkRecord from this LinkViewModel
     /// </summary>
@@ -522,5 +541,4 @@ public class LinkViewModel : CollectionItemViewModel<LinkListViewModel, LinkView
     {
         OnPropertyChanged(nameof(IsEditButtonShown));
     }
-
 }

--- a/ViewModel/Scenes/MemberViewModel.cs
+++ b/ViewModel/Scenes/MemberViewModel.cs
@@ -70,20 +70,19 @@ public sealed class MemberViewModel : CollectionItemViewModel<MemberListViewMode
 
     public override bool Equals(object? obj)
     {
-        var other = obj as MemberViewModel;
         return
-            other != null &&
-            DeviceId == other.DeviceId &&
-            Group == other.Group &&
-            IsController == other.IsController &&
-            IsResponder == other.IsResponder &&
-            OnLevel == other.OnLevel &&
-            RampRate == other.RampRate;
+            obj is MemberViewModel memberViewModel &&
+            DeviceId == memberViewModel.DeviceId &&
+            Group == memberViewModel.Group &&
+            IsController == memberViewModel.IsController &&
+            IsResponder == memberViewModel.IsResponder &&
+            OnLevel == memberViewModel.OnLevel &&
+            RampRate == memberViewModel.RampRate;
     }
 
     public override int GetHashCode()
     {
-        throw new NotImplementedException();
+        return DeviceId.ToInt();
     }
 
     public SceneViewModel SceneViewModel => containingList.SceneViewModel;


### PR DESCRIPTION
This change uses the helpers in `XAMLHelpers` to bring a newly added link into view in the Device view. It also ensures that the link is added to the `LinkListViewModel` regardless of current filter, giving feedback to the user that the link has indeed been added.

We now `Add/RemoveObserver` of the `AllLinkDatabase` in `ActiveStateChange` instead of at creation of the `LinkListViewModel` which avoid adding the observer several times, which then would make us add a new `LinkViewModel` several times.

Also added Equals method to `LinkViewModel` to look them up by value in `ListLinkViewModel` for example using `IndexOf`. This is important as the `LinkViewModel` that we have in hand might not always be the same instance as what is in the `LinkListViewModel`, forcing us to look for the one in the list by value.