### PR TITLE
Ensure that we actually read the device when using the "Read and Update Device" menu item.

### DIFF
--- a/Insteon/Model/Device.cs
+++ b/Insteon/Model/Device.cs
@@ -1619,7 +1619,7 @@ public sealed class Device : DeviceBase
     public object? ScheduleSync(Scheduler.JobCompletionCallback<bool>? completionCallback = null, object? group = null, TimeSpan delay = new TimeSpan(), 
         Scheduler.Priority priority = Scheduler.Priority.Medium, bool forceRead = false)
     {
-        if (!NeedsSync)
+        if (!NeedsSync && !forceRead)
         {
             return null;
         }

--- a/Insteon/Model/DeviceProperties.cs
+++ b/Insteon/Model/DeviceProperties.cs
@@ -22,8 +22,6 @@ namespace Insteon.Model;
 /// </summary>
 public sealed class DeviceProperties : List<DeviceProperty>
 {
-    internal SyncStatus LastStatus;
-
     internal DeviceProperties() { }
 
     internal DeviceProperties(DeviceProperties properties)


### PR DESCRIPTION
Honor `forceRead` when the user clicks "Read and Update Device" menu otherwise we don't actually read the device, which is contrary to the goal of that command.
Removed unused field in `DeviceProperties`.