### PR TITLE
UX and code improvements and simplifications to link grid views

### DIFF
--- a/UnoApp/Views/Hub/HubChannelListPage.xaml
+++ b/UnoApp/Views/Hub/HubChannelListPage.xaml
@@ -1,16 +1,17 @@
-﻿<!-- Copyright 2022 Christian Fortini
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+﻿<!--
+    Copyright 2022 Christian Fortini
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 -->
 
 <local:HubChannelListPageBase

--- a/UnoApp/Views/Hub/HubChannelView.xaml
+++ b/UnoApp/Views/Hub/HubChannelView.xaml
@@ -1,16 +1,17 @@
-﻿<!-- Copyright 2022 Christian Fortini
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+﻿<!--
+    Copyright 2022 Christian Fortini
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 -->
 
 <ContentControl

--- a/UnoApp/Views/Links/LinkHostViews.xaml
+++ b/UnoApp/Views/Links/LinkHostViews.xaml
@@ -76,7 +76,7 @@
                         ItemContainerStyle="{StaticResource CustomGridViewItemExpanded}"
                         ItemTemplate="{StaticResource ControllerLinkGridViewItem}"
                         ItemsSource="{x:Bind ControllerLinks, Mode=OneWay}"
-                        SelectedItem="{x:Bind ControllerLinks.SelectedLink, Mode=TwoWay}"
+                        SelectedItem="{x:Bind SelectedControllerLink, Mode=TwoWay}"
                         ItemClick="OnItemClick"
                         IsItemClickEnabled="True"/>
                 </StackPanel>
@@ -116,7 +116,7 @@
                         ItemContainerStyle="{StaticResource CustomGridViewItemExpanded}"
                         ItemTemplate="{StaticResource ResponderLinkGridViewItem}"
                         ItemsSource="{x:Bind ResponderLinks, Mode=OneWay}"
-                        SelectedItem="{x:Bind ResponderLinks.SelectedLink, Mode=TwoWay}"
+                        SelectedItem="{x:Bind SelectedResponderLink, Mode=TwoWay}"
                         ItemClick="OnItemClick"
                         IsItemClickEnabled="True"/>
                 </StackPanel>
@@ -129,6 +129,7 @@
                     ItemContainerStyle="{StaticResource CustomGridViewItemExpanded}"
                     ItemTemplateSelector="{StaticResource LinkTemplateSelector}"
                     ItemsSource="{x:Bind Links.View, Mode=OneWay}"
+                    SelectedItem="{x:Bind SelectedLink, Mode=TwoWay}"
                     IsItemClickEnabled="True"
                     ItemClick="OnItemClick">
                     <GridView.GroupStyle>

--- a/ViewModel/Links/LinkListViewModel.cs
+++ b/ViewModel/Links/LinkListViewModel.cs
@@ -39,18 +39,6 @@ public class LinkListViewModel : ObservableCollection<LinkViewModel>
     private readonly LinkHostViewModel host;
     public Device Device => this.host.Device;
 
-    // Data binding support
-    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
-    {
-        // Let the base class handle it
-        OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
-    }
-
-    /// <summary>
-    /// Whether the underlying AllLinkDataBase has changed and this list needs to be rebuilt
-    /// </summary>
-    internal bool Changed;
-
     /// <summary>
     /// Get a LinkViewModel in this list by its AllLinkRecord using the record uid
     /// This will get the correct LinkViewModel even if there are duplicates of the record
@@ -62,7 +50,7 @@ public class LinkListViewModel : ObservableCollection<LinkViewModel>
         foreach (var linkViewModel in this)
         {
             if (linkViewModel.AllLinkRecord.Uid.Equals(record.Uid))
-                return linkViewModel;   
+                return linkViewModel;
         }
         return null;
     }
@@ -72,7 +60,7 @@ public class LinkListViewModel : ObservableCollection<LinkViewModel>
     /// </summary>
     /// <param name="record"></param>
     /// <returns></returns>
-    public int GetLinkIndex(AllLinkRecord record)
+    public int GetLinkViewModelIndex(AllLinkRecord record)
     {
         for (var i = 0; i < Count; i++)
         {
@@ -83,41 +71,6 @@ public class LinkListViewModel : ObservableCollection<LinkViewModel>
         }
         return -1;
     }
-
-    /// <summary>
-    /// Currently selected link in the list
-    /// </summary>
-    public LinkViewModel? SelectedLink
-    {
-        get => _selectedLink;
-        set
-        {
-            if (value != _selectedLink)
-            {
-                if (_selectedLink != null)
-                    _selectedLink.IsSelected = false;
-                _selectedLink = value;
-                if (_selectedLink != null)
-                    _selectedLink.IsSelected = true;
-                OnPropertyChanged();
-            }
-        }
-    }
-    private LinkViewModel? _selectedLink;
-
-    /// <summary>
-    /// LinkViewModel currently being edited when creating or editing a link
-    /// </summary>
-    public LinkViewModel? EditedLink
-    {
-        get => _editedLinkViewModel;
-        private set
-        {
-            _editedLinkViewModel = value;
-            OnPropertyChanged();
-        }
-    }
-    private LinkViewModel? _editedLinkViewModel;
 
     /// <summary>
     /// Add the link to the device database


### PR DESCRIPTION
- Removed the `LinkListViewModel` change tracking logic and instead now rebuild the lists each time the device or channel view gets activated. There was no major benefit to tracking the changes, since they happen relatively rarely.
- Now tracking the selection on link lists and restoring it after rebuilding the lists. This ensure a consistent preservation of the selected link in each list (as long as the same `LinkHostViewModel` is used).
- We now have a single selected link across controller and responder links, simplifying the UX.
- Ensured that the HubChannel view always show the link group headers with the "Add" button, even when that group is empty (no link in it)
- Renamed `GetLinkIndex` to `GetLinkViewModeIndex` for consistency with `GetLinkViewModel`.
- Removed now unnecessary code in `LinkListViewModel`.