### PR TITLE
Upgraded to .net9.0 and Uno 6.0.146

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>
-      net8.0-android;
-      net8.0-ios;
-      net8.0-maccatalyst;
-      net8.0-windows10.0.26100;
-      net8.0-desktop;
-      net8.0-browserwasm;
-    </TargetFrameworks>
+  <TargetFrameworks>
+    net9.0-android;
+    net9.0-ios;
+    net9.0-windows10.0.26100;
+    net9.0
+  </TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/Insteon/Insteon.csproj
+++ b/Insteon/Insteon.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>
-      net8.0-android;
-      net8.0-ios;
-      net8.0-maccatalyst;
-      net8.0-windows10.0.26100;
-      net8.0-desktop;
-      net8.0-browserwasm;
-    </TargetFrameworks>
+  <TargetFrameworks>
+    net9.0-android;
+    net9.0-ios;
+    net9.0-windows10.0.26100;
+    net9.0
+  </TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ msbuild /r /t:Restore /p:Configuration=Release /v:minimal
 ```
 3. Then run the following to build the package:
 ```
-msbuild /p:TargetFramework=net8.0-windows10.0.22621 /p:Configuration=Release /p:Platform=x64 /p:PublishUnsignedPackage=true /p:AppxPackageDir="<output directory>" /v:minimal
+msbuild /p:TargetFramework=net9.0-windows10.0.22621 /p:Configuration=Release /p:Platform=x64 /p:PublishUnsignedPackage=true /p:AppxPackageDir="<output directory>" /v:minimal
 ```
 4. This creates an `.msix` file in the specificed `<output directory>`, (e.g., `c:\temp\output\`), which you can install on your machine or any other machine with developer mode turned on. To install, open a vanilla Powershell window **running as administrator** and run the following:
 ```
@@ -132,11 +132,9 @@ You can also build and deploy HouzLinc to an Android device from the command lin
 8. HouzLinc should now be installed on your device. You can run it from the app drawer or home screen.
 
 ### Other platforms
-HouzLinc can be built for and run on frameworks Desktop and WebAssembly (WASM). Just select these launch profiles in Visual Studio.
+HouzLinc can be built for the Desktop framework and run on Windows or Mac that way. On Windows, just select the `HouseLinc(Destop)` launch profile in Visual Studio. Instead of using Windows App SDK / WinUI3, HouzLinc will use the Uno implementation of that framework. This offers a convenient environment to test on the Uno implementation of the Windows App SDK framework.
 
-If built for Desktop, it will run on Windows, but instead of using Windows App SDK / WinUI3, it will use the Uno implementation backed by Skia for rendering. This offers an easy to deploy environment to test the Uno implementation of the Windows App SDK.
-
-When built for WebAssembly, HouzLinc will run in your favorite browser.
+HouzLinc can also be built for WebAssembly and run in your favorite browser. Simply use the `HouseLinc(WebAssembly)` launch configration in Visual Studio. However [limitations on cross-site behavior](https://platform.uno/docs/articles/interop/MSAL.html) prevent signing in to OneDrive at this time. This means that HouzLinc cannot access the OneDrive configuration file when running in a browser, only local files. The Uno team proposes workarounds (see link above) that I have not yet tested.
 
 I am also working on making HouzLinc run on MacOS and iOS.
 
@@ -184,7 +182,7 @@ The project currently contains some non-UI unit tests for the Insteon layer. The
 
 Tests can also be built from the command line using msbuild. Navigate to UnitTestApp folder under the root of the repo and run the following command:
 ```
-msbuild /p:TargetFramework=net8.0-windows10.0.22621 /p:Configuration=Release /p:Platform=x64 /p:PublishUnsignedPackage=true /p:AppxPackageDir="<output directory>" /v:minimal
+msbuild /p:TargetFramework=net9.0-windows10.0.22621 /p:Configuration=Release /p:Platform=x64 /p:PublishUnsignedPackage=true /p:AppxPackageDir="<output directory>" /v:minimal
 ```
 
 ### Contribution

--- a/UnitTestApp/UnitTestApp.csproj
+++ b/UnitTestApp/UnitTestApp.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.26100</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.26100</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>UnitTestApp</RootNamespace>
     <Platforms>x86;x64;ARM64</Platforms>

--- a/UnoApp/Platforms/Android/Main.Android.cs
+++ b/UnoApp/Platforms/Android/Main.Android.cs
@@ -1,5 +1,4 @@
 using Android.Runtime;
-using Com.Nostra13.Universalimageloader.Core;
 
 namespace UnoApp.Droid;
 
@@ -15,18 +14,5 @@ public sealed class Application : Microsoft.UI.Xaml.NativeApplication
     public Application(IntPtr javaReference, JniHandleOwnership transfer)
         : base(() => new App(), javaReference, transfer)
     {
-        ConfigureUniversalImageLoader();
-    }
-
-    private static void ConfigureUniversalImageLoader()
-    {
-        // Create global configuration and initialize ImageLoader with this config
-        ImageLoaderConfiguration config = new ImageLoaderConfiguration
-            .Builder(Context)
-            .Build();
-
-        ImageLoader.Instance.Init(config);
-
-        ImageSource.DefaultImageLoader = ImageLoader.Instance.LoadImageAsync;
     }
 }

--- a/UnoApp/Platforms/Android/MsalActivity.Android.cs
+++ b/UnoApp/Platforms/Android/MsalActivity.Android.cs
@@ -1,6 +1,7 @@
-using Microsoft.Identity.Client;
 using Android.App;
 using Android.Content;
+using Android.Content.PM;
+using Microsoft.Identity.Client;
 
 namespace UnoApp.Droid;
 
@@ -8,7 +9,10 @@ namespace UnoApp.Droid;
 // However, the redirect URI configured in the Azure portal is different from what the doc above states.
 // See https://learn.microsoft.com/en-us/azure/developer/mobile-apps/azure-mobile-apps/quickstarts/uno/authentication
 // The redirect URI is of the form "msauth://com.lakesideapps.houzlinc/..."
-[Activity(Exported = true)]
+[Activity(
+    NoHistory = true,
+    LaunchMode = LaunchMode.SingleTask, 
+    Exported = true)]
 [IntentFilter(new[] { Intent.ActionView },
    Categories = new[] { Intent.CategoryBrowsable, Intent.CategoryDefault },
    DataHost = "com.lakesideapps.houzlinc",

--- a/UnoApp/Platforms/WebAssembly/Program.cs
+++ b/UnoApp/Platforms/WebAssembly/Program.cs
@@ -1,13 +1,17 @@
+using Microsoft.Extensions.Hosting;
+using Uno.UI.Hosting;
+
 namespace UnoApp;
 
 public class Program
 {
-    private static App? _app;
-
-    public static int Main(string[] args)
+    public static async Task Main(string[] args)
     {
-        Microsoft.UI.Xaml.Application.Start(_ => _app = new App());
+        var host = UnoPlatformHostBuilder.Create()
+            .App(() => new App())
+            .UseWebAssembly()
+            .Build();
 
-        return 0;
+        await host.RunAsync();
     }
 }

--- a/UnoApp/Properties/launchSettings.json
+++ b/UnoApp/Properties/launchSettings.json
@@ -42,7 +42,7 @@
     },
     "HouzLinc (Desktop WSL2)": {
       "commandName": "WSL2",
-      "commandLineArgs": "{ProjectDir}/bin/Debug/net8.0-desktop/HouzLinc.dll",
+      "commandLineArgs": "{ProjectDir}/bin/Debug/net9.0-desktop/HouzLinc.dll",
       "distributionName": "",
       "compatibleTargetFramework": "desktop"
     }

--- a/UnoApp/UnoApp.csproj
+++ b/UnoApp/UnoApp.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>
-      net8.0-android;
-      net8.0-ios;
-      net8.0-maccatalyst;
-      net8.0-windows10.0.26100;
-      net8.0-desktop;
-      net8.0-browserwasm;
-    </TargetFrameworks>
+  <TargetFrameworks>
+    net9.0-android;
+    net9.0-ios;
+    net9.0-windows10.0.26100;
+    net9.0-browserwasm;
+    net9.0-desktop;net9.0
+  </TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>
@@ -89,23 +88,23 @@
   Platform specific properties and dependencies
   -->
   <Choose>
-    <When Condition="'$(TargetFramework)'=='net8.0-ios'">
+    <When Condition="'$(TargetFramework)'=='net9.0-ios'">
     </When>
-    <When Condition="'$(TargetFramework)'=='net8.0-android'">
+    <When Condition="'$(TargetFramework)'=='net9.0-android'">
       <PropertyGroup>
         <SupportedOSPlatformVersion>33.0</SupportedOSPlatformVersion>
       </PropertyGroup>
     </When>
-    <When Condition="'$(TargetFramework)'=='net8.0-maccatalyst'">
+    <When Condition="'$(TargetFramework)'=='net9.0-maccatalyst'">
     </When>
-    <When Condition="'$(TargetFramework)'=='net8.0-windows10.0.19041'">
+    <When Condition="'$(TargetFramework)'=='net9.0-windows10.0.19041'">
       <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
       </ItemGroup>
     </When>
-    <When Condition="'$(TargetFramework)'=='net8.0-desktop'">
+    <When Condition="'$(TargetFramework)'=='net9.0-desktop'">
     </When>
-    <When Condition="'$(TargetFramework)'=='net8.0-browserwasm'">
+    <When Condition="'$(TargetFramework)'=='net9.0-browserwasm'">
     </When>
   </Choose>
 

--- a/ViewModel/Settings/OneDrive.cs
+++ b/ViewModel/Settings/OneDrive.cs
@@ -97,11 +97,6 @@ public sealed class OneDrive
     // Redicrect URI registered with the application
 #if __ANDROID__
     private string redirectUri1 = null!;
-#elif DESKTOP
-    // TODO: need to understand why on Desktop the redirectUri is supposed to be localhost
-    // TODO: Consider switching to Uno's MSALAuthenticationProvider
-    // TODO: use #if DESKTOP once this code is moved to the main project
-    private const string redirectUri1 = "http://localhost:44321/";
 #elif __WASM__
     private const string redirectUri1 = "http://localhost:5000/authentication/login-callback.htm";
 #elif WINDOWS
@@ -111,9 +106,14 @@ public sealed class OneDrive
     // To get around this, we try the nativeclient url first, and loopback if that fails.
     private const string redirectUri1 = "https://login.microsoftonline.com/common/oauth2/nativeclient";
     private const string redirectUri2 = "http://localhost:44321/";
-#else
+#elif __iOS__
     // TODO: figure out the redirectUri for iOS
     private const string redirectUri1 = "";
+#else // DESKTOP
+    // TODO: need to understand why on Desktop the redirectUri is supposed to be localhost
+    // TODO: Consider switching to Uno's MSALAuthenticationProvider
+    // TODO: use #if DESKTOP once this code is moved to the main project
+    private const string redirectUri1 = "http://localhost:44321/";
 #endif
 
     // Use Instance to acquire the singleton instance of OneDrive

--- a/ViewModel/ViewModel.csproj
+++ b/ViewModel/ViewModel.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>
-      net8.0-android;
-      net8.0-ios;
-      net8.0-maccatalyst;
-      net8.0-windows10.0.26100;
-      net8.0-desktop;
-      net8.0-browserwasm;
-    </TargetFrameworks>
+<TargetFrameworks>
+  net9.0-android;
+  net9.0-ios;
+  net9.0-windows10.0.26100;
+  net9.0
+</TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.0.110"
+    "Uno.Sdk": "6.0.146"
   },
 
   "sdk": {


### PR DESCRIPTION
Upgraded to .net9.0 and Uno 6.0.146.
Removed `net9.0-desktop` and `net9.0-browserwasm` from the list of frameworks for the libraries and replaced by `net9.0` based on comments [here](https://github.com/unoplatform/uno/issues/20312#issuecomment-2887282787).
Removed dependencies on `UniversalImageLoader` which were causing problems and are not necessary anymore.
Added code in Main function in program.cs for platforms Desktop and WebAssembly.
Adapted README.cs as needed.
