### PR TITLE
Prepare for turning on SkiaRenderer but did not turn it on yet.

### DIFF
--- a/UnoApp/Platforms/Desktop/Program.cs
+++ b/UnoApp/Platforms/Desktop/Program.cs
@@ -25,12 +25,13 @@ public class Program
     {
         var host = UnoPlatformHostBuilder.Create()
             .App(() => new App())
+#if HAS_UNO_SKIA
             .UseX11()
             .UseLinuxFrameBuffer()
             .UseMacOS()
             .UseWin32()
+#endif
             .Build();
-
         host.Run();
     }
 }

--- a/UnoApp/UnoApp.csproj
+++ b/UnoApp/UnoApp.csproj
@@ -5,7 +5,8 @@
     net9.0-ios;
     net9.0-windows10.0.26100;
     net9.0-browserwasm;
-    net9.0-desktop;net9.0
+    net9.0-desktop;
+    net9.0
   </TargetFrameworks>
 
     <OutputType>Exe</OutputType>

--- a/UnoApp/Views/Devices/DeviceTemplateSelector.cs
+++ b/UnoApp/Views/Devices/DeviceTemplateSelector.cs
@@ -23,14 +23,14 @@ public sealed class DeviceTemplateSelector : DataTemplateSelector
     {
         if (item != null && item is DeviceViewModel dvm)
         {
-#if DESKTOP || __WASM__
-            // On Desktop and WASM, "container" is the ContentPresenter.
+#if HAS_UNO_SKIA
+            // On Uno, "container" is the ContentPresenter.
             // Either its TemplatedParent or Parent contains the DeviceView with the template resource.
             // Note that TemplatedParent and Parent can sometimes be null (not sure exactly when).
             // We ignore the call and return null in that case. We will get called back.
             var dv = (container is ContentPresenter cp) ? (cp.TemplatedParent ?? cp.Parent) as DeviceView : null;
 #else
-            // On WindowsAppSDK, Android, iOS, "container" is the DeviceViews content control
+            // On WindowsAppSDK, "container" is the DeviceViews content control
             var dv = container as DeviceView;
 #endif
             if (dv != null)

--- a/UnoApp/Views/Settings/SettingsPage.xaml
+++ b/UnoApp/Views/Settings/SettingsPage.xaml
@@ -1,16 +1,17 @@
-﻿<!-- Copyright 2022 Christian Fortini
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+﻿<!--
+    Copyright 2022 Christian Fortini
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 -->
 
 <base:PageWithViewModels
@@ -70,11 +71,7 @@
                 <local:HubSettingsView Margin="0,15,0,15" Content="{x:Bind SettingsViewModel}"/>
 
                 <ctkControls:SettingsCard Description="Is currently located at:" Header="House Configuration File">
-                    <ctkControls:SettingsCard.Resources>
-                        <x:Double x:Key="SettingsCardWrapThreshold">800</x:Double>
-                        <x:Double x:Key="SettingsCardWrapNoIconThreshold">600</x:Double>
-                    </ctkControls:SettingsCard.Resources>
-                    <TextBlock Text="{x:Bind SettingsViewModel.HouseFilePath, Mode=OneWay}" TextWrapping="Wrap"/>
+                    <TextBlock Text="{x:Bind SettingsViewModel.HouseFilePath, Mode=OneWay}" TextWrapping="Wrap" MaxWidth="300"/>
                 </ctkControls:SettingsCard>
 
                 <ctkControls:SettingsCard Description="Automatically open the house configuration file next time HouzLinc is restarted" Header="Auto Open Configuration">


### PR DESCRIPTION
When turning on the `SkiaRenderer` feature, a couple of behavior breaking changes needed to be handled. In particular:
- The `Main` function for Desktop needs to initialize some additional services, or we get a crash at startup. 
- A workaround for a semantic difference between Uno and WinUI3 in the parameters of `DataTemplateSelector.SelectTemplateCore` needs to be extended to all platforms using Uno, not just Desktop and WASM,
- Uno bug 20601 in WithUnoHelpers requires a workaround for Android. 

With these changes, Skia Renderer can be turned on by adding `SkiaRenderer` to `UnoFeatures` in `UnoApp.csproj`:
```
    <UnoFeatures>
      Lottie;
      ...
      Toolkit;
      SkiaRenderer;
    </UnoFeatures>
```

This change does not turn on `SkiaRenderer` yet. I want to run it locally for a while to see if there are more changes like these to address before turning it on by default.