### PR TITLE
Upgrade to latest production version of the .Net SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,10 +5,6 @@
     "Uno.Sdk": "6.2.29"
   },
   "sdk": {
-    // TODO: Revert to allowPrerelease line below when https://github.com/dotnet/sdk/issues/49180 is resolved.
-    "version": "9.0.204",
-    "rollForward": "latestPatch"
-
-    //"allowPrerelease": false,
+    "allowPrerelease": false,
   }
 }

--- a/global.json
+++ b/global.json
@@ -5,6 +5,6 @@
     "Uno.Sdk": "6.2.29"
   },
   "sdk": {
-    "allowPrerelease": false,
+    "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Reverted to using the latest production version of the .Net SDK now that https://github.com/dotnet/sdk/issues/49180 appears to be resolved. 