### PR TITLE
Disabled SkiaRenderer

### DIFF
--- a/UnoApp/UnoApp.csproj
+++ b/UnoApp/UnoApp.csproj
@@ -46,7 +46,6 @@
       Material;
       Navigation;
       Toolkit;
-      SkiaRenderer;
     </UnoFeatures>
   </PropertyGroup>
 


### PR DESCRIPTION
Disabling SkiaRenderer for now, to avoid fatal error when launching the Release configuration of the app on Android emulator or devices. Filed issue with Uno Platform: https://github.com/unoplatform/uno/issues/21451 