### PR TITLE
Ensured that the MSAL cache worked on Desktop

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-  <TargetFrameworks>
-    net9.0-android;
-    net9.0-ios;
-    net9.0-windows10.0.26100;
-    net9.0
-  </TargetFrameworks>
+    <TargetFrameworks>
+      net9.0-android;
+      net9.0-ios;
+      net9.0-windows10.0.26100;
+      net9.0-browserwasm;
+      net9.0-desktop;
+      net9.0
+    </TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/Insteon/Insteon.csproj
+++ b/Insteon/Insteon.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-  <TargetFrameworks>
-    net9.0-android;
-    net9.0-ios;
-    net9.0-windows10.0.26100;
-    net9.0
-  </TargetFrameworks>
+    <TargetFrameworks>
+      net9.0-android;
+      net9.0-ios;
+      net9.0-windows10.0.26100;
+      net9.0-browserwasm;
+      net9.0-desktop;
+      net9.0
+    </TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/UnoApp/UnoApp.csproj
+++ b/UnoApp/UnoApp.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-  <TargetFrameworks>
-    net9.0-android;
-    net9.0-ios;
-    net9.0-windows10.0.26100;
-    net9.0-browserwasm;
-    net9.0-desktop;
-    net9.0
-  </TargetFrameworks>
+    <TargetFrameworks>
+      net9.0-android;
+      net9.0-ios;
+      net9.0-windows10.0.26100;
+      net9.0-browserwasm;
+      net9.0-desktop;
+      net9.0
+    </TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/ViewModel/Settings/OneDrive.cs
+++ b/ViewModel/Settings/OneDrive.cs
@@ -20,7 +20,7 @@ using Uno.UI.MSAL;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Options;
 
-#if WINDOWS
+#if !__iOS__ && !__ANDROID__
 using Microsoft.Identity.Client.Extensions.Msal;
 #endif
 
@@ -87,7 +87,7 @@ public sealed class OneDrive
     // see https://learn.microsoft.com/en-us/onedrive/developer/rest-api/concepts/permissions_reference?view=odsp-graph-online#files-permissions
     private string[] scopes = ["Files.ReadWrite.AppFolder"];
 
-#if WINDOWS
+#if !__IOS__ && !__ANDROID__
     // MSAL Cache persistence on Windows.
     // On Android and iOS the cache persistence is handled by the platform.
     private const string CacheFileName = "ehouse_msal_cache.txt";
@@ -109,11 +109,11 @@ public sealed class OneDrive
 #elif __iOS__
     // TODO: figure out the redirectUri for iOS
     private const string redirectUri1 = "";
-#else // DESKTOP
+#else
     // TODO: need to understand why on Desktop the redirectUri is supposed to be localhost
     // TODO: Consider switching to Uno's MSALAuthenticationProvider
-    // TODO: use #if DESKTOP once this code is moved to the main project
-    private const string redirectUri1 = "http://localhost:44321/";
+    private const string redirectUri1 = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+    private const string redirectUri2 = "http://localhost:44321/";
 #endif
 
     // Use Instance to acquire the singleton instance of OneDrive
@@ -196,7 +196,7 @@ public sealed class OneDrive
                 return false;
             }
 
-#if WINDOWS
+#if !__IOS__ && !__ANDROID__
             // On Android and iOS the MSAL cache persistence is handled by the platform.
             // On Windows we need to handle it ourselves.
 

--- a/ViewModel/ViewModel.csproj
+++ b/ViewModel/ViewModel.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-<TargetFrameworks>
-  net9.0-android;
-  net9.0-ios;
-  net9.0-windows10.0.26100;
-  net9.0
-</TargetFrameworks>
+    <TargetFrameworks>
+      net9.0-android;
+      net9.0-ios;
+      net9.0-windows10.0.26100;
+      net9.0-browserwasm;
+      net9.0-desktop;
+      net9.0
+    </TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->


### PR DESCRIPTION
On Desktop we need to implement its own MSAL cache, like on WindowAppSDK.
Also ensured that the target framework list was the same for all projects as it was not and that generated a yellow banner warning from Uno Platform.