### PR TITLE
Removed use of DESKTOP which is not defined anyway

### DIFF
--- a/UnoApp/AppShell.xaml.cs
+++ b/UnoApp/AppShell.xaml.cs
@@ -148,11 +148,9 @@ public sealed partial class AppShell : Page, INotifyPropertyChanged
     /// </summary>
     public void SetTitleBar()
     {
-#if !DESKTOP
         // https://github.com/unoplatform/uno/issues/15789
         App.MainWindow.ExtendsContentIntoTitleBar = true;
         App.MainWindow.SetTitleBar(AppTitleBar);
-#endif
     }
 
     // We use the width of the NavView pane in the compact form as the height of the titlebar,


### PR DESCRIPTION
Custom title bar is not supported by Uno on Desktop framework. This conditional was supposed to prevent setting it up for that framework, but DESKTOP is not defined, so this didn't prevent anything. 