### PR TITLE
Don't show the custom title bar content on Desktop 

### DIFF
--- a/UnoApp/AppShell.xaml.cs
+++ b/UnoApp/AppShell.xaml.cs
@@ -148,9 +148,15 @@ public sealed partial class AppShell : Page, INotifyPropertyChanged
     /// </summary>
     public void SetTitleBar()
     {
+#if DESKTOP
+        // Custom title bar is not supported on Desktop
+        // It would appear below the OS title bar, wasting space, so hide it
         // https://github.com/unoplatform/uno/issues/15789
+        AppTitleBar.Visibility = Visibility.Collapsed;
+#else
         App.MainWindow.ExtendsContentIntoTitleBar = true;
         App.MainWindow.SetTitleBar(AppTitleBar);
+#endif
     }
 
     // We use the width of the NavView pane in the compact form as the height of the titlebar,

--- a/UnoApp/Platforms/Desktop/Program.cs
+++ b/UnoApp/Platforms/Desktop/Program.cs
@@ -19,8 +19,6 @@ using Uno.UI.Hosting;
 namespace UnoApp;
 public class Program
 {
-    private static App? _app;
-
     public static void Main(string[] args)
     {
         var host = UnoPlatformHostBuilder.Create()

--- a/UnoApp/UnoApp.csproj
+++ b/UnoApp/UnoApp.csproj
@@ -172,4 +172,8 @@
     <UnoSplashScreen Include="Assets\SplashScreen\splash_screen.svg" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0-desktop' OR '$(TargetFramework)' == 'net9.0'">
+    <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Since the Desktop platform does not support custom title bar content yet, the custom content is only duplicating the system title bar. We hide it.