### PR TITLE
Added GitHub actions script to build and create release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore packages
+        run: msbuild /r /t:Restore /p:Configuration=Release
+        working-directory: UnoApp
+
+      - name: Build Windows MSIX package
+        run: msbuild /p:TargetFramework=net9.0-windows10.0.26100 /p:Configuration=Release /p:Platform=x64 /p:PublishUnsignedPackage=true /p:AppxPackageDir="./publish/"
+        working-directory: UnoApp
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: HouzLinc-Windows
+          path: UnoApp/publish/*.msix
+
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Build and publish Android APK
+        run: dotnet publish -f net9.0-android -c Release -o ./publish
+        working-directory: UnoApp
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: HouzLinc-Android
+          path: UnoApp/publish/*.apk
+
+  create-release:
+    needs: [build-windows, build-android]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: HouzLinc-Windows
+          path: ./artifacts/windows
+
+      - name: Download Android artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: HouzLinc-Android
+          path: ./artifacts/android
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ./artifacts/windows/*.msix
+            ./artifacts/android/*.apk
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/HouzLinc.sln
+++ b/HouzLinc.sln
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		global.json = global.json
 		narrowview.png = narrowview.png
 		README.md = README.md
+		.github\workflows\release.yml = .github\workflows\release.yml
 		sceneview-color.png = sceneview-color.png
 	EndProjectSection
 EndProject


### PR DESCRIPTION
The new `release.yml` GitHub action script is kicked off by pushing a new release tag and:
- builds the Windows release app,
- builds the Android release app,
- uploads the resulting artifacts to the `publish` directory under the application project (`UnoApp`),
- create a new GitHub release,
- add the `msix` and `apk` files to the list of artifacts of the release. 