### PR TITLE
Fixed up GitHub action file to build the project and create a release 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: Build and Release
 
+# This builds the project for Windows and Android, then creates a GitHub release
+# with the built artifacts whenever:
+# - a tag matching 'v*' is pushed in any branch, or
+# - a branch matching 'release-v*' is pushed.
+
 on:
   push:
     tags:


### PR DESCRIPTION
This change fixes up the `release.yml` GitHub action file, which now builds the project for Windows and Android, then creates a GitHub release with the built artifacts whenever:
- a tag matching 'v*' is pushed in any branch, or
- a branch matching 'release-v*' is pushed.