### PR TITLE
Fixes and improvements in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: HouzLinc-Windows
-          path: UnoApp/artifacts/*.msix  # the msix file is in a subdirectory
+          path: UnoApp/artifacts/*.msix
 
   build-android:
     runs-on: ubuntu-latest
@@ -138,7 +138,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            ./artifacts/windows/**/*.msix
+            ./artifacts/windows/*.msix
             ./artifacts/android/*.apk
           draft: false
           prerelease: true


### PR DESCRIPTION
This fixes remaining bugs in `release.yml` and also renames the produced `msix` file:
- Don't try to create a release if triggered by a push of the release branch (GitHub will only create releases on a tag push)
- Renamed output `msix` file to `HouzLinc-xxx.msix` for clarity and consistency with Android.
- Place the `msix` file(s) at the top of the uploaded artifact instead of in a subfolder