### PR TITLE
Fix Windows build error when building from command line

### DIFF
--- a/UnoApp/UnoApp.csproj
+++ b/UnoApp/UnoApp.csproj
@@ -153,7 +153,7 @@
   <!-- Dynamically propagate publisher, identity name and version to Package.appxmanifest -->
   <Target Name="GenerateAppxManifest"
           DependsOnTargets="ValidateStoreVersion"
-          BeforeTargets="GenerateAppxPackageFile;GeneratePackageAppxManifest;GenerateManifests"
+          BeforeTargets="_ValidatePresenceOfAppxManifestItems;PrepareForBuild"
           Condition="'$(TargetFramework)'=='net9.0-windows10.0.26100'">
 
     <!-- Copy source manifest template to generated manifest -->
@@ -186,6 +186,11 @@
              Value="$(ApplicationDisplayVersion).$(ApplicationVersion)" />
     <Message Importance="High"
              Text="Setting Identity Version: $(ApplicationDisplayVersion).$(ApplicationVersion)" />
+
+    <!-- Mark the generated file as part of the build outputs -->
+    <ItemGroup>
+      <FileWrites Include="Package.appxmanifest" />
+    </ItemGroup>
   </Target>
 
   <!--


### PR DESCRIPTION
Problem: when running the build from the command line, `Package.appmanifest` is not generated early enough during the build process and the build fails. This file is copied from `Package.template.appxmanifest` by `UnoApp.csproj` target `GenerateAppxManifest`

Fix: force target `GenerateAppxManifest` to run earlier by tweaking its `BeforeTargets`.
Bonus: mark `Package.appxmanifest` as a build output file to be properly tracked by the build system for incremental builds and clean operations.