### PR TITLE
Allow for pre-release versions to be coded as v0.0.0-rc instead of v0.0.0-beta

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
     <!-- MinVer configuration -->
     <MinVerTagPrefix>v</MinVerTagPrefix>
-    <MinVerDefaultPreReleaseIdentifiers>preview;beta</MinVerDefaultPreReleaseIdentifiers>
+    <MinVerDefaultPreReleaseIdentifiers>rc</MinVerDefaultPreReleaseIdentifiers>
     <MinVerVerbosity>minimal</MinVerVerbosity>
     <MinVerIgnoreHeight>true</MinVerIgnoreHeight>
   </PropertyGroup>


### PR DESCRIPTION
RC tags will be used on release branches while numbers only tags will be used in main.