### PR TITLE
Better error handling during load/merge/save cycle of house configuration file

### DIFF
--- a/ViewModel/Settings/NetworkScanner.cs
+++ b/ViewModel/Settings/NetworkScanner.cs
@@ -29,7 +29,7 @@ public class NetworkScanner
     private const int minMaskBits = 22;
 
     // Max number of scanning threads
-    private static int maxDegreeOfParallelism = Environment.ProcessorCount * 2;
+    private static int maxDegreeOfParallelism = Environment.ProcessorCount * 8;
 
     /// <summary>
     /// Scan all subnets this computer is connected (except loopback and vEthernet) to for a host with the specified port open.


### PR DESCRIPTION
Problem: when saving the house config file to storage, if loading of the current state of the file failed, we would still write the current state out to the storage provider and hide the error. This could potentially lead to data loss depending on the actual state of the house config in memory at the time and could also potentially override previous changes from other instances of the app.

Fix: bail out whenever there is an error reading the current state of the file and do not attempt to write out anything to storage. Propagate the error up and let the caller handle the failure (it will re-attempt saving at a later date). This means that latest local changes to the house config won't be saved until we manage to load the file successfully again, but at least it does not corrupt the current state of the file in storage, minimizing the damage.

