### PR TITLE
Clear Gateway HttpClient cache when copying from another gateway

### DIFF
--- a/Insteon/Base/Gateway.cs
+++ b/Insteon/Base/Gateway.cs
@@ -78,6 +78,8 @@ public sealed class Gateway
         return DeviceId.ToInt();
     }
 
+    // Copy values from another gateway object with the same id
+    // Generates observer notifications for all properties that changed
     internal void CopyFrom(Gateway fromGateway)
     {
         Debug.Assert(DeviceId == fromGateway.DeviceId);
@@ -87,6 +89,9 @@ public sealed class Gateway
         Port = fromGateway.Port;
         Username = fromGateway.Username;
         Password = fromGateway.Password;
+
+        // Release the httpClient cache as we may have changed the properties above
+        httpClient = null;
     }
 
     internal bool IsIdenticalTo(Gateway other)

--- a/Insteon/Model/Devices.cs
+++ b/Insteon/Model/Devices.cs
@@ -62,6 +62,7 @@ public sealed class Devices : OrderedKeyedList<Device>
         {
             if (fromDevices2.TryGetEntry(device.GetHashCode(), out var fromDevice))
             {
+                // We copy in place to generate the proper property change notifications
                 device.CopyFrom(fromDevice);
                 fromDevices2.Remove(fromDevice);
             }
@@ -77,7 +78,8 @@ public sealed class Devices : OrderedKeyedList<Device>
             Remove(device);
         }
 
-        // Add a copy of any new device in the "from" list
+        // Add a copy of any new device in the "from" list.
+        // We copy in place after adding so as to generate the property change notifications
         foreach (var device in fromDevices2)
         {
             var newDevice = new Device(this, device.Id).AddObserver(House.ModelObserver);


### PR DESCRIPTION
Fixes #192. Gateway objects contain an `HttpClient` instance that is obtained once and get reused until cleared. When copying values from another Gateway instance in `Gateway.CopyFrom`, we were not clearing the `HttpClient` even though the new property values might require obtaining a new instance. This would happen in particular after the user entered wrong Hub settings, which would create an incorrect `HttpClient` resulting in the devices showing disconnected. When the user then corrected these values, the `HttpClient` would not get reacquired and the devices would not reconnect. The fix is simply to null out `httpClient` in `CopyFrom` to force reacquiring it next time `HttpClient.Get` is called. 

This change also edits a few comments to stress that calling `CopyFrom` is necessary (as opposed to creating new instances) in order to generate property change notifications and deltas.