### PR TITLE
Reenable network scanning to locate the Hub with improved performance

### DIFF
--- a/ViewModel/Settings/SettingsViewModel.cs
+++ b/ViewModel/Settings/SettingsViewModel.cs
@@ -1,4 +1,4 @@
-/* Copyright 2022 ChristianGa Fortini
+/* Copyright 2022 Christian Fortini
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -635,7 +635,7 @@ public class SettingsViewModel : PageViewModel
     public InsteonID HubInsteonID
     {
         get => hubInsteonID;
-        set
+        set 
         {
             if (value != hubInsteonID)
             {


### PR DESCRIPTION
This change re-enables network scanning to discover the Hub on the local network. That functionality had been turned off with PR #191.

Changes to `NetworkScanner` and calling site to improve efficiency:
- Made the `NetworkScanner` instantiable rather than static to help not launch more than one network scan at once: caller should check if an instance is already instantiated and cancel it and recreate a fresh instance if so. 
- Made cancellation actually work and fixed leaks and synchronicity issues in the handling of the cancellation token. 
- Also ensured that all subnet scans are cancelled whenever the cancellation token is set. 
- Ensure that we reliably returned false when cancelled by user actions and true when cancelled because the hub is found.
- Moved the callback to identify the hub on a worker thread and implemented a light-weight version of that check that runs on a worker thread (See `SettingsViewModel.VerifyHubAsync`). This helps terminate the scan quickly if the hub device is found by removing the switch to the UI thread.
- Ensured that individual device scans are all done on worker threads (as opposed to UI thread) using `ConfigureAwait(false)` on relevant async methods.
- Set the maximum parallelism of the scan to # of processors x 8, i.e., 64 on an 8 proc machine. This seems to give appropriate performance on average PC and Android phone.
- Added/edited comments for clarity